### PR TITLE
Add Key for APK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
   build-and-release:
     name: Build APK and publish release
     runs-on: ubuntu-latest
+    environment:
+      name: Key APK
 
     steps:
       - name: Checkout
@@ -118,6 +120,28 @@ jobs:
             fi
           done
 
+      - name: Prepare APK signing key
+        env:
+          APK_SIGNING_PRIVATE_KEY: ${{ secrets.APK_SIGNING_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          SIGNING_DIR=".build/signing"
+          SIGNING_KEY_PATH="${SIGNING_DIR}/apk-signing-key.pem"
+          PUBLIC_KEY_PATH="dist/apk-signing-public.pem"
+
+          if [ -z "${APK_SIGNING_PRIVATE_KEY:-}" ]; then
+            echo "::error::Missing APK_SIGNING_PRIVATE_KEY environment secret"
+            exit 1
+          fi
+
+          mkdir -p "$SIGNING_DIR" dist
+          umask 077
+          printf '%s\n' "$APK_SIGNING_PRIVATE_KEY" > "$SIGNING_KEY_PATH"
+          openssl pkey -in "$SIGNING_KEY_PATH" -pubout -out "$PUBLIC_KEY_PATH"
+
+          echo "APK_SIGNING_KEY_PATH=$(realpath "$SIGNING_KEY_PATH")" >> "$GITHUB_ENV"
+          echo "APK_SIGNING_PUBLIC_KEY_PATH=$(realpath "$PUBLIC_KEY_PATH")" >> "$GITHUB_ENV"
+
       - name: Build APK
         run: |
           set -euo pipefail
@@ -194,6 +218,9 @@ jobs:
             --script "post-upgrade:${SCRIPTS_DIR}/post-upgrade" \
             --output "$ARTIFACT_PATH"
 
+          # --- sign apk ---
+          "$APK_BIN" adbsign --sign-key "$APK_SIGNING_KEY_PATH" "$ARTIFACT_PATH"
+
           # --- sha256 + package index ---
           printf '%s  %s\n' \
             "$("$MKHASH_BIN" sha256 "$ARTIFACT_PATH")" \
@@ -209,6 +236,9 @@ jobs:
               "$(basename "$ARTIFACT_PATH")"
           )
 
+          # --- sign repository index ---
+          "$APK_BIN" adbsign --sign-key "$APK_SIGNING_KEY_PATH" "${OUTPUT_DIR}/packages.adb"
+
           ls -lh "$OUTPUT_DIR/"
 
       - name: Create GitHub Release
@@ -220,3 +250,4 @@ jobs:
             dist/*.apk
             dist/*.sha256
             dist/*.adb
+            dist/*.pem


### PR DESCRIPTION
Prepare and use an APK signing key during the release job. Adds an environment name for the job, a step that reads APK_SIGNING_PRIVATE_KEY from Secrets, writes a private key with restrictive permissions, extracts the public key with openssl, and exposes their paths via GITHUB_ENV. After building the APK, the workflow now signs the produced APK and the repository package index (packages.adb) using the signing key, and includes the public PEM in the release assets. The step errors out if the signing secret is missing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated APK signing implemented in release workflow using private keys
  * Repository index signing added to build process
  * Public key artifacts now included in GitHub releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->