### PR TITLE
Install guide into readme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ env:
   OPENWRT_SUBTARGET: '64'
   OPENWRT_TOOLCHAIN: 'gcc-14.3.0_musl'
   PACKAGE_NAME: 'luci-app-nordvpn-easy'
+  PACKAGE_INDEX_NAME: 'luci-app-nordvpn-easy.adb'
   PACKAGE_LICENSE: 'Unlicense'
   PACKAGE_DEPENDS: 'ca-certificates curl jq luci-base kmod-wireguard wireguard-tools'
   PACKAGE_DESCRIPTION: 'NordVPN Easy LuCI app with bundled backend for OpenWrt'
@@ -241,7 +242,7 @@ jobs:
               --allow-untrusted \
               --sign-key "$APK_SIGNING_KEY_PATH" \
               --description "${PACKAGE_INDEX_DESCRIPTION}" \
-              --output packages.adb \
+              --output "${PACKAGE_INDEX_NAME}" \
               "$(basename "$ARTIFACT_PATH")"
           )
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ health-check and recovery logic.
 The package tree is the source of truth. The repository no longer depends on
 legacy root-level direct-install files.
 
+## Installation
+
+1. Log in to LuCI.
+2. Open `System -> Software`.
+3. Click `Configure apk`.
+4. Add this repository index URL:
+   `https://github.com/tis24dev/NordVPN-Easy-OpenWrt/releases/latest/download/luci-app-nordvpn-easy.adb`
+5. Save the `apk` configuration.
+6. Click `Update lists...`.
+7. In the `Filter` box, search for `nordvpn-easy`.
+8. Install `luci-app-nordvpn-easy`.
+9. Log out from LuCI.
+10. Log in again.
+11. Open `Services -> NordVPN Easy`.
+12. Configure the service.
+
+The configuration guide will be expanded separately.
+
 ## Runtime model
 
 The runtime model is service-driven and one-shot based:


### PR DESCRIPTION
Introduce PACKAGE_INDEX_NAME in the GitHub Actions release workflow and use it as the output filename for the apk index (instead of a hardcoded packages.adb). Update README with step-by-step LuCI installation instructions that reference the generated luci-app-nordvpn-easy.adb index URL so users can add the repo and install the package via LuCI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added step-by-step installation instructions for setting up the application via the LuCI interface.

* **Chores**
  * Updated release workflow to improve package artifact handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->