### PR TITLE
Add country list caching and UI refresh

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/advanced.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/advanced.js
@@ -117,7 +117,7 @@ return view.extend({
 		o.rmempty = false;
 
 		o = s.option(form.Button, '_setup', _('Back to Setup'));
-		o.inputstyle = 'reset';
+		o.inputstyle = 'apply';
 		o.onclick = function() {
 			window.location.href = L.url('admin', 'services', 'nordvpn-easy');
 		};

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -1,9 +1,130 @@
 'use strict';
 'require form';
+'require fs';
+'require ui';
+'require uci';
 'require view';
 
+var COUNTRIES_CACHE_PATH = '/tmp/nordvpn-easy-countries.json';
+
+function parseCountries(countriesRaw) {
+	var countries = [];
+
+	try {
+		countries = JSON.parse(countriesRaw || '[]');
+	} catch (e) {
+		countries = [];
+	}
+
+	return countries.filter(function(country) {
+		return country && country.name && country.code;
+	}).sort(function(a, b) {
+		return String(a.name).localeCompare(String(b.name));
+	});
+}
+
+function renderCountryChoices(selectEl, countries, currentCountry) {
+	var seenCurrent = false;
+
+	if (!selectEl)
+		return;
+
+	while (selectEl.firstChild)
+		selectEl.removeChild(selectEl.firstChild);
+
+	selectEl.appendChild(E('option', { value: '' }, [ _('Automatic') ]));
+
+	countries.forEach(function(country) {
+		var value = String(country.code);
+		selectEl.appendChild(E('option', { value: value }, [
+			_('%s (%s)').format(country.name, value)
+		]));
+
+		if (value === currentCountry)
+			seenCurrent = true;
+	});
+
+	if (currentCountry && !seenCurrent) {
+		selectEl.appendChild(E('option', { value: currentCountry }, [
+			_('Current value: %s').format(currentCountry)
+		]));
+	}
+
+	selectEl.value = currentCountry || '';
+}
+
+const CountrySelectValue = form.ListValue.extend({
+	refreshCountries(buttonEl, section_id) {
+		buttonEl.disabled = true;
+
+		return fs.exec('/etc/init.d/nordvpn-easy', [ 'refresh_countries_force' ]).then(function(res) {
+			var message;
+
+			if (res.code !== 0) {
+				message = res.stderr ? res.stderr.trim() : _('Country refresh failed.');
+				throw new Error(_('Country refresh failed with exit code %d: %s').format(res.code, message));
+			}
+
+			return fs.read(COUNTRIES_CACHE_PATH);
+		}).then(function(countriesRaw) {
+			var selectEl = document.getElementById(this.cbid(section_id));
+			var currentCountry = selectEl ? selectEl.value : '';
+			var countries = parseCountries(countriesRaw);
+
+			renderCountryChoices(selectEl, countries, currentCountry);
+			ui.addNotification(null, E('p', _('Country list refreshed.')), 'info');
+		}.bind(this)).catch(function(err) {
+			ui.addNotification(null, E('p', err.message), 'error');
+		}).finally(function() {
+			buttonEl.disabled = false;
+		});
+	},
+
+	renderWidget(section_id, option_index, cfgvalue) {
+		var choices = this.transformChoices();
+		var widget = new ui.Select((cfgvalue != null) ? cfgvalue : this.default, choices, {
+			id: this.cbid(section_id),
+			size: this.size,
+			sort: this.keylist,
+			widget: this.widget,
+			optional: this.optional,
+			orientation: this.orientation,
+			placeholder: this.placeholder,
+			validate: this.getValidator(section_id),
+			disabled: (this.readonly != null) ? this.readonly : this.map.readonly
+		});
+
+		return E('div', {
+			'style': 'display:flex;gap:0.5rem;align-items:center;'
+		}, [
+			E('div', { 'style': 'flex:1;min-width:0;' }, [ widget.render() ]),
+			E('button', {
+				'class': 'cbi-button cbi-button-apply',
+				'type': 'button',
+				'click': ui.createHandlerFn(this, function(section_id, ev) {
+					ev.preventDefault();
+					return this.refreshCountries(ev.currentTarget, section_id);
+				}, section_id),
+				'disabled': (this.readonly != null) ? this.readonly : this.map.readonly
+			}, [ _('Refresh') ])
+		]);
+	}
+});
+
 return view.extend({
-	render: function() {
+	load: function() {
+		return L.resolveDefault(fs.exec('/etc/init.d/nordvpn-easy', [ 'refresh_countries' ]), null).then(function() {
+			return Promise.all([
+				L.resolveDefault(fs.read(COUNTRIES_CACHE_PATH), '[]'),
+				uci.load('nordvpn_easy')
+			]);
+		});
+	},
+
+	render: function(data) {
+		var countriesRaw = data[0];
+		var currentCountry = uci.get('nordvpn_easy', 'main', 'vpn_country') || '';
+		var countries = parseCountries(countriesRaw);
 		var m, s, o;
 
 		m = new form.Map('nordvpn_easy', _('NordVPN Easy'),
@@ -22,10 +143,18 @@ return view.extend({
 		o.rmempty = false;
 		o.description = _('Required. NordVPN access token.');
 
-		o = s.option(form.Value, 'vpn_country', _('Country Filter'));
-		o.placeholder = 'IT / Italy / 106';
+		o = s.option(CountrySelectValue, 'vpn_country', _('Server Country'));
+		o.value('', _('Automatic'));
 		o.rmempty = true;
-		o.description = _('Optional. Use a country code, a full country name or a NordVPN country id.');
+		o.description = _('Optional. Country list is refreshed automatically every 24 hours.');
+
+		countries.forEach(function(country) {
+			var value = String(country.code);
+			o.value(value, _('%s (%s)').format(country.name, value));
+		});
+
+		if (currentCountry && !countries.some(function(country) { return String(country.code) === currentCountry; }))
+			o.value(currentCountry, _('Current value: %s').format(currentCountry));
 
 		o = s.option(form.Button, '_advanced', _('Advanced'));
 		o.inputstyle = 'apply';

--- a/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
@@ -12,10 +12,12 @@ RUNTIME_CONFIG='/var/etc/nordvpn-easy.conf'
 CORE_SCRIPT='/usr/libexec/nordvpn-easy/core.sh'
 CRON_PATH='/etc/cron.d/nordvpn-easy'
 HOTPLUG_PATH='/etc/hotplug.d/iface/95-nordvpn-easy'
-EXTRA_COMMANDS='setup check rotate install_hooks remove_hooks render_runtime_config'
+EXTRA_COMMANDS='setup check rotate refresh_countries refresh_countries_force install_hooks remove_hooks render_runtime_config'
 EXTRA_HELP='  setup                 Run setup immediately
   check                 Run one health check immediately
   rotate                Force server rotation immediately
+  refresh_countries     Refresh the cached NordVPN country list
+  refresh_countries_force Force-refresh the cached NordVPN country list
   install_hooks         Install cron and hotplug hooks
   remove_hooks          Remove cron and hotplug hooks
   render_runtime_config Render the temporary shell config'
@@ -244,4 +246,12 @@ check() {
 
 rotate() {
 	run_core_action rotate
+}
+
+refresh_countries() {
+	run_core_action refresh_countries
+}
+
+refresh_countries_force() {
+	run_core_action refresh_countries_force
 }

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -20,6 +20,9 @@ INTERFACE_RESTART_DELAY="${INTERFACE_RESTART_DELAY:-10}"
 POST_RESTART_DELAY="${POST_RESTART_DELAY:-60}"
 
 SERVER_LIST_FILE='/tmp/nordvpn.json'
+COUNTRIES_CACHE_FILE='/tmp/nordvpn-easy-countries.json'
+COUNTRIES_CACHE_TS_FILE='/tmp/nordvpn-easy-countries.timestamp'
+COUNTRIES_CACHE_TTL="${COUNTRIES_CACHE_TTL:-86400}"
 NORDVPN_API='https://api.nordvpn.com/v1'
 COUNTRIES_URL="${NORDVPN_API}/servers/countries"
 SERVER_RECOMMENDATIONS_URL_BASE="${NORDVPN_API}/servers/recommendations?filters\\[servers_technologies\\]\\[identifier\\]=wireguard_udp&limit=10"
@@ -61,12 +64,14 @@ log () {
 
 usage () {
   cat <<EOF
-Usage: $0 [check|setup|rotate|run|help] [config_file]
+Usage: $0 [check|setup|rotate|refresh_countries|refresh_countries_force|run|help] [config_file]
 
 Commands:
   check   Run one VPN health-check cycle (default)
   setup   Configure the WireGuard interface and firewall if needed
   rotate  Download a fresh server list and switch server
+  refresh_countries  Refresh the cached NordVPN country list if needed
+  refresh_countries_force  Force-refresh the cached NordVPN country list
   run     Backward-compatible alias for check
   help    Show this message
 
@@ -174,22 +179,87 @@ get_private_key () {
   }
 }
 
+countries_cache_is_fresh () {
+  [ -f "$COUNTRIES_CACHE_FILE" ] || return 1
+  [ -f "$COUNTRIES_CACHE_TS_FILE" ] || return 1
+
+  NOW_TS=$(date +%s 2>/dev/null) || return 1
+  CACHE_TS=$(cat "$COUNTRIES_CACHE_TS_FILE" 2>/dev/null) || return 1
+
+  case "$CACHE_TS" in
+    ''|*[!0-9]*)
+      return 1
+      ;;
+  esac
+
+  [ $((NOW_TS - CACHE_TS)) -lt "$COUNTRIES_CACHE_TTL" ]
+}
+
+refresh_countries_cache () {
+  FORCE_REFRESH="${1:-0}"
+  COUNTRIES_CACHE_TMP="${COUNTRIES_CACHE_FILE}.tmp.$$"
+  COUNTRIES_TS_TMP="${COUNTRIES_CACHE_TS_FILE}.tmp.$$"
+
+  if [ "$FORCE_REFRESH" -ne 1 ] && countries_cache_is_fresh; then
+    return 0
+  fi
+
+  curl -fsS --connect-timeout 15 --max-time 30 "$COUNTRIES_URL" | jq -ce '
+    [ .[] | select(
+        (.id != null) and
+        ((.name // "") != "") and
+        ((.code // "") != "")
+      ) | {
+        id: .id,
+        name: .name,
+        code: .code
+      }
+    ] | sort_by(.name | ascii_downcase)
+  ' > "$COUNTRIES_CACHE_TMP" 2>/dev/null || {
+    rm -f "$COUNTRIES_CACHE_TMP" "$COUNTRIES_TS_TMP"
+    [ -f "$COUNTRIES_CACHE_FILE" ] && return 0
+    log 'ERROR: COULD NOT REFRESH COUNTRY LIST CACHE'
+    return 1
+  }
+
+  date +%s > "$COUNTRIES_TS_TMP" || {
+    rm -f "$COUNTRIES_CACHE_TMP" "$COUNTRIES_TS_TMP"
+    [ -f "$COUNTRIES_CACHE_FILE" ] && return 0
+    log 'ERROR: COULD NOT WRITE COUNTRY CACHE TIMESTAMP'
+    return 1
+  }
+
+  mv "$COUNTRIES_CACHE_TMP" "$COUNTRIES_CACHE_FILE" || {
+    rm -f "$COUNTRIES_CACHE_TMP" "$COUNTRIES_TS_TMP"
+    [ -f "$COUNTRIES_CACHE_FILE" ] && return 0
+    log 'ERROR: COULD NOT UPDATE COUNTRY LIST CACHE'
+    return 1
+  }
+
+  mv "$COUNTRIES_TS_TMP" "$COUNTRIES_CACHE_TS_FILE" || {
+    rm -f "$COUNTRIES_TS_TMP"
+    [ -f "$COUNTRIES_CACHE_FILE" ] && return 0
+    log 'ERROR: COULD NOT UPDATE COUNTRY CACHE TIMESTAMP'
+    return 1
+  }
+}
+
 resolve_country_filter () {
   [ -n "$RESOLVED_COUNTRY_ID" ] && return 0
   [ -z "$VPN_COUNTRY" ] && return 0
 
-  COUNTRIES_JSON=$(curl -fsS --connect-timeout 15 --max-time 30 "$COUNTRIES_URL") || {
+  refresh_countries_cache || {
     log 'ERROR: COULD NOT RETRIEVE COUNTRY LIST'
     return 1
   }
 
-  COUNTRY_MATCH=$(printf '%s' "$COUNTRIES_JSON" | jq -er --arg query "$VPN_COUNTRY" '
+  COUNTRY_MATCH=$(jq -er --arg query "$VPN_COUNTRY" '
     [ .[] | select(
       ((.id | tostring) == $query) or
       ((.code // "" | ascii_downcase) == ($query | ascii_downcase)) or
       ((.name // "" | ascii_downcase) == ($query | ascii_downcase))
     ) ][0] | [.id, .name, .code] | @tsv
-  ' 2>/dev/null) || {
+  ' "$COUNTRIES_CACHE_FILE" 2>/dev/null) || {
     log "ERROR: COUNTRY '$VPN_COUNTRY' NOT FOUND"
     return 1
   }
@@ -471,6 +541,7 @@ configure_vpn_interface () {
 }
 
 bootstrap_if_needed () {
+  refresh_countries_cache || true
   resolve_country_filter || return 1
 
   if ! vpn_is_configured; then
@@ -549,7 +620,7 @@ ACTION='check'
 
 if [ $# -gt 0 ]; then
   case "$1" in
-    check|setup|rotate|run|help)
+    check|setup|rotate|refresh_countries|refresh_countries_force|run|help)
       ACTION="$1"
       shift
       ;;
@@ -586,6 +657,12 @@ case "$ACTION" in
     ;;
   rotate)
     rotate_action
+    ;;
+  refresh_countries)
+    refresh_countries_cache
+    ;;
+  refresh_countries_force)
+    refresh_countries_cache 1
     ;;
   *)
     usage


### PR DESCRIPTION
Introduce a cached NordVPN country list and a UI refresh flow. Adds client-side support (config.js, advanced.js) for a country select widget with a Refresh button, parsing/rendering helpers, and automatic load of /tmp/nordvpn-easy-countries.json; also tweaks the advanced page button style. Extend the init script to expose refresh_countries and refresh_countries_force commands. Update core.sh to implement country cache files, TTL-based freshness checks, curl+jq-based refresh logic, force refresh handling, and integration with resolve_country_filter and bootstrap so country data is used and can be refreshed on demand. Includes error handling and UI notifications for refresh operations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Country selection now uses an interactive dropdown menu instead of manual text input
  * Added "Automatic" option to allow the VPN to automatically select the optimal country
  * Added refresh button to manually update the available countries list
  * Improved country list loading performance and responsiveness

* **UI Improvements**
  * Enhanced button styling for improved visual consistency throughout the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->