### PR TITLE
Fix setup & vpn ip view

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -122,12 +122,6 @@ const CountrySelectValue = form.ListValue.extend({
 	}
 });
 
-const PublicIPValue = form.DummyValue.extend({
-	textvalue() {
-		return E('span', { 'id': PUBLIC_IP_STATUS_ID }, [ _('Collecting data...') ]);
-	}
-});
-
 function updatePublicIp() {
 	return fs.exec('/etc/init.d/nordvpn-easy', [ 'public_ip' ]).then(function(res) {
 		var statusEl = document.getElementById(PUBLIC_IP_STATUS_ID);
@@ -136,13 +130,57 @@ function updatePublicIp() {
 		if (!statusEl)
 			return;
 
-		statusEl.textContent = (res.code === 0 && publicIp) ? publicIp : _('Unavailable');
+		statusEl.textContent = (res.code === 0 && publicIp && publicIp !== 'null' && publicIp !== 'undefined')
+			? publicIp
+			: _('Unavailable');
 	}).catch(function() {
 		var statusEl = document.getElementById(PUBLIC_IP_STATUS_ID);
 
 		if (statusEl)
 			statusEl.textContent = _('Unavailable');
 	});
+}
+
+function runServiceAction(action) {
+	return fs.exec('/etc/init.d/nordvpn-easy', [ action ]).then(function(res) {
+		var lines = [];
+
+		if (res.stdout)
+			lines.push(res.stdout.trim());
+
+		if (res.stderr)
+			lines.push(res.stderr.trim());
+
+		return {
+			action: action,
+			code: res.code,
+			message: lines.filter(function(line) {
+				return line;
+			}).join('\n') || _('Command completed.')
+		};
+	});
+}
+
+function runServiceActions(actions) {
+	var results = [];
+
+	return actions.reduce(function(chain, action) {
+		return chain.then(function() {
+			return runServiceAction(action).then(function(result) {
+				results.push(result);
+			});
+		});
+	}, Promise.resolve()).then(function() {
+		return results;
+	});
+}
+
+function summarizeActionFailures(results) {
+	return results.filter(function(result) {
+		return result.code !== 0;
+	}).map(function(result) {
+		return _('%s failed with exit code %d: %s').format(result.action, result.code, result.message);
+	}).join('\n');
 }
 
 return view.extend({
@@ -161,6 +199,8 @@ return view.extend({
 		var countries = parseCountries(countriesRaw);
 		var m, s, o;
 
+		this.initialEnabled = (uci.get('nordvpn_easy', 'main', 'enabled') !== '0');
+
 		m = new form.Map('nordvpn_easy', _('NordVPN Easy'),
 			_('Configure the minimum settings required to connect NordVPN Easy.'));
 
@@ -172,7 +212,11 @@ return view.extend({
 		o.default = '1';
 		o.rmempty = false;
 
-		o = s.option(PublicIPValue, '_public_ip', _('Public IP'));
+		o = s.option(form.DummyValue, '_public_ip', _('Public IP'));
+		o.rawhtml = true;
+		o.cfgvalue = function() {
+			return '<span id="%s">%s</span>'.format(PUBLIC_IP_STATUS_ID, _('Collecting data...'));
+		};
 
 		o = s.option(form.Value, 'nordvpn_token', _('NordVPN Token'));
 		o.password = true;
@@ -200,5 +244,56 @@ return view.extend({
 			updatePublicIp();
 			return node;
 		});
+	},
+
+	handleSaveApply: function(ev, mode) {
+		var previousEnabled = !!this.initialEnabled;
+
+		return this.handleSave(ev).then(L.bind(function() {
+			if (this._uciAppliedHandler)
+				document.removeEventListener('uci-applied', this._uciAppliedHandler);
+
+			this._uciAppliedHandler = L.bind(function() {
+				document.removeEventListener('uci-applied', this._uciAppliedHandler);
+				this._uciAppliedHandler = null;
+
+				uci.unload('nordvpn_easy');
+				uci.load('nordvpn_easy').then(L.bind(function() {
+					var currentEnabled = (uci.get('nordvpn_easy', 'main', 'enabled') !== '0');
+					var actions = [];
+					var successMessage = '';
+
+					this.initialEnabled = currentEnabled;
+
+					if (!previousEnabled && currentEnabled) {
+						actions = [ 'setup', 'install_hooks' ];
+						successMessage = _('NordVPN Easy enabled: setup completed and hooks installed.');
+					}
+					else if (previousEnabled && !currentEnabled) {
+						actions = [ 'remove_hooks' ];
+						successMessage = _('NordVPN Easy disabled: hooks removed.');
+					}
+
+					if (!actions.length)
+						return;
+
+					return runServiceActions(actions).then(function(results) {
+						var failures = summarizeActionFailures(results);
+
+						if (failures) {
+							ui.addNotification(null, E('p', failures), 'error');
+							return;
+						}
+
+						ui.addNotification(null, E('p', successMessage), 'info');
+					}).catch(function(err) {
+						ui.addNotification(null, E('p', _('Automatic runtime sync failed: ') + err.message), 'error');
+					});
+				}, this));
+			}, this);
+
+			document.addEventListener('uci-applied', this._uciAppliedHandler);
+			ui.changes.apply(mode == '0');
+		}, this));
 	}
 });


### PR DESCRIPTION
Remove the custom PublicIPValue component and render the Public IP field as raw HTML; update updatePublicIp() to treat 'null'/'undefined' as unavailable. Add helper functions runServiceAction, runServiceActions and summarizeActionFailures to run /etc/init.d/nordvpn-easy actions, aggregate stdout/stderr, and summarize failures. Track the initial enabled state and override handleSaveApply to listen for uci-applied, detect enable/disable transitions, and automatically run setup/install_hooks when enabling or remove_hooks when disabling, showing success or error notifications based on command results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed public IP status display to correctly show "Unavailable" when data is invalid or missing.

* **New Features**
  * Service enable/disable now automatically performs required setup and cleanup operations.
  * Added notifications for operation success and failure summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->