### PR TITLE
Add runtime disable and server sync

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -158,6 +158,12 @@ function runServiceAction(action) {
 				return line;
 			}).join('\n') || _('Command completed.')
 		};
+	}).catch(function(err) {
+		return {
+			action: action,
+			code: -1,
+			message: (err && err.message) ? err.message : String(err)
+		};
 	});
 }
 
@@ -200,6 +206,7 @@ return view.extend({
 		var m, s, o;
 
 		this.initialEnabled = (uci.get('nordvpn_easy', 'main', 'enabled') !== '0');
+		this.initialCountry = currentCountry;
 
 		m = new form.Map('nordvpn_easy', _('NordVPN Easy'),
 			_('Configure the minimum settings required to connect NordVPN Easy.'));
@@ -248,6 +255,7 @@ return view.extend({
 
 	handleSaveApply: function(ev, mode) {
 		var previousEnabled = !!this.initialEnabled;
+		var previousCountry = this.initialCountry || '';
 
 		return this.handleSave(ev).then(L.bind(function() {
 			if (this._uciAppliedHandler)
@@ -260,18 +268,24 @@ return view.extend({
 				uci.unload('nordvpn_easy');
 				uci.load('nordvpn_easy').then(L.bind(function() {
 					var currentEnabled = (uci.get('nordvpn_easy', 'main', 'enabled') !== '0');
+					var currentCountry = uci.get('nordvpn_easy', 'main', 'vpn_country') || '';
 					var actions = [];
 					var successMessage = '';
 
 					this.initialEnabled = currentEnabled;
+					this.initialCountry = currentCountry;
 
 					if (!previousEnabled && currentEnabled) {
 						actions = [ 'setup', 'install_hooks' ];
 						successMessage = _('NordVPN Easy enabled: setup completed and hooks installed.');
 					}
 					else if (previousEnabled && !currentEnabled) {
-						actions = [ 'remove_hooks' ];
-						successMessage = _('NordVPN Easy disabled: hooks removed.');
+						actions = [ 'disable_runtime' ];
+						successMessage = _('NordVPN Easy disabled: VPN interface stopped and hooks removed.');
+					}
+					else if (currentEnabled && previousCountry !== currentCountry) {
+						actions = [ 'setup' ];
+						successMessage = _('Server country updated: VPN server synchronized.');
 					}
 
 					if (!actions.length)

--- a/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
@@ -12,7 +12,7 @@ RUNTIME_CONFIG='/var/etc/nordvpn-easy.conf'
 CORE_SCRIPT='/usr/libexec/nordvpn-easy/core.sh'
 CRON_PATH='/etc/cron.d/nordvpn-easy'
 HOTPLUG_PATH='/etc/hotplug.d/iface/95-nordvpn-easy'
-EXTRA_COMMANDS='setup check rotate refresh_countries refresh_countries_force public_ip install_hooks remove_hooks render_runtime_config'
+EXTRA_COMMANDS='setup check rotate refresh_countries refresh_countries_force public_ip install_hooks remove_hooks disable_runtime render_runtime_config'
 EXTRA_HELP='  setup                 Run setup immediately
   check                 Run one health check immediately
   rotate                Force server rotation immediately
@@ -21,6 +21,7 @@ EXTRA_HELP='  setup                 Run setup immediately
   public_ip             Print the current public IP
   install_hooks         Install cron and hotplug hooks
   remove_hooks          Remove cron and hotplug hooks
+  disable_runtime       Disable the VPN interface and remove hooks
   render_runtime_config Render the temporary shell config'
 
 cfg_enabled='1'
@@ -208,12 +209,33 @@ remove_hooks() {
 	restart_cron_service
 }
 
+disable_vpn_runtime() {
+	load_service_config
+	remove_hooks
+
+	[ "$(uci -q get "network.${cfg_vpn_if}.proto" 2>/dev/null)" = 'wireguard' ] || return 0
+
+	uci set "network.${cfg_vpn_if}.disabled"='1'
+	uci commit network || {
+		log_service_error "failed to commit network while disabling ${cfg_vpn_if}"
+		return 1
+	}
+
+	ifdown "$cfg_vpn_if" >/dev/null 2>&1 || true
+
+	/etc/init.d/network reload >/dev/null 2>&1 ||
+	/etc/init.d/network restart >/dev/null 2>&1 || {
+		log_service_error "failed to reload network while disabling ${cfg_vpn_if}"
+		return 1
+	}
+}
+
 start() {
 	load_service_config
 
 	if [ "$cfg_enabled" -ne 1 ]; then
-		remove_hooks
-		echo "$SERVICE_NAME is disabled in UCI; hooks removed."
+		disable_vpn_runtime || return 1
+		echo "$SERVICE_NAME is disabled in UCI; hooks removed and VPN interface disabled."
 		return 0
 	fi
 
@@ -259,4 +281,8 @@ refresh_countries_force() {
 
 public_ip() {
 	run_core_action public_ip
+}
+
+disable_runtime() {
+	disable_vpn_runtime
 }

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -137,6 +137,21 @@ vpn_is_configured () {
   [ "$(uci -q get "network.${VPN_IF}.proto" 2>/dev/null)" = 'wireguard' ]
 }
 
+ensure_vpn_interface_enabled () {
+  [ "$(uci -q get "network.${VPN_IF}.disabled" 2>/dev/null)" = '1' ] || return 0
+
+  uci -q delete "network.${VPN_IF}.disabled"
+  uci commit network || {
+    log "ERROR: COULD NOT COMMIT NETWORK CONFIGURATION WHILE ENABLING $VPN_IF"
+    return 1
+  }
+
+  /etc/init.d/network reload || {
+    log "ERROR: NETWORK RELOAD FAILED WHILE ENABLING $VPN_IF"
+    return 1
+  }
+}
+
 pick_ping_ip () {
   eval "printf '%s\n' \"\$IP$(awk 'BEGIN { srand(); print int((rand()*10000000)) % 20 }')\""
 }
@@ -464,6 +479,29 @@ EOF
   set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY"
 }
 
+current_server_matches_recommendations () {
+  CURRENT_SERVER=$(uci -q get "network.${VPN_IF}server.endpoint_host" 2>/dev/null)
+
+  [ -n "$CURRENT_SERVER" ] || return 1
+
+  jq -e --arg current "$CURRENT_SERVER" '
+    [ .[] | select(.station == $current) ] | length > 0
+  ' "$SERVER_LIST_FILE" >/dev/null 2>&1
+}
+
+sync_server_selection () {
+  vpn_is_configured || return 0
+  get_servers_list || return 1
+
+  if current_server_matches_recommendations; then
+    log 'Current VPN server already matches the selected country/filter'
+    return 0
+  fi
+
+  log 'Current VPN server does not match the selected country/filter, changing server'
+  change_vpn_server reload
+}
+
 change_vpn_server () {
   CURRENT_SERVER=$(uci -q get "network.${VPN_IF}server.endpoint_host" 2>/dev/null)
   SERVER_CANDIDATES_FILE="/tmp/nordvpn.candidates.$$"
@@ -570,6 +608,8 @@ bootstrap_if_needed () {
 
   if ! vpn_is_configured; then
     configure_vpn_interface || return 1
+  else
+    ensure_vpn_interface_enabled || return 1
   fi
 
   ensure_vpn_in_wan_zone || return 1
@@ -687,7 +727,7 @@ case "$ACTION" in
     bootstrap_if_needed && check_once
     ;;
   setup)
-    bootstrap_if_needed && log 'NordVPN configuration is ready'
+    bootstrap_if_needed && sync_server_selection && log 'NordVPN configuration is ready'
     ;;
   rotate)
     rotate_action


### PR DESCRIPTION
UI: handle errors from runServiceAction, remember initial vpn country, and trigger a setup when the VPN is enabled or when the selected country changes (so servers are synchronized). Update success messages accordingly.

Init script: add disable_runtime command and disable_vpn_runtime helper to stop the VPN interface, mark it disabled in UCI, remove hooks, and reload network. Expose the new command in EXTRA_COMMANDS and help text; use disable_vpn_runtime when service is disabled in UCI.

Core script: add ensure_vpn_interface_enabled to clear the network disabled flag and reload network; add logic to detect whether the current server matches recommended servers and sync (change) it when needed. Call ensure_vpn_interface_enabled when an already-configured VPN is started, and invoke server synchronization during setup.

These changes ensure disabling the service actually tears down the runtime interface and that changing the configured country updates the active VPN server. JavaScript error handling improves robustness when service actions fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * VPN configuration now detects country selection changes and applies them automatically.
  * Server selection automatically validates against and syncs with NordVPN server recommendations.

* **Bug Fixes**
  * Improved error handling with detailed error messages when operations fail.
  * Enhanced state management during enable/disable transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->