### PR TITLE
Add diagnostics view, log export, logger and ifup

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/diagnostics.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/diagnostics.js
@@ -1,0 +1,82 @@
+'use strict';
+'require fs';
+'require ui';
+'require view';
+
+function downloadLogFile(content) {
+	var now = new Date();
+	var name = 'nordvpn-easy-diagnostics-%04d-%02d-%02d_%02d-%02d-%02d.log'.format(
+		now.getFullYear(),
+		now.getMonth() + 1,
+		now.getDate(),
+		now.getHours(),
+		now.getMinutes(),
+		now.getSeconds()
+	);
+	var blob = new Blob([ content ], { type: 'text/plain;charset=utf-8' });
+	var url = window.URL.createObjectURL(blob);
+	var link = E('a', {
+		'style': 'display:none',
+		'href': url,
+		'download': name
+	});
+
+	document.body.appendChild(link);
+	link.click();
+	document.body.removeChild(link);
+	window.URL.revokeObjectURL(url);
+}
+
+return view.extend({
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null,
+
+	render: function() {
+		return E([
+			E('h2', _('NordVPN Easy Diagnostics')),
+			E('div', { 'class': 'cbi-section-descr' }, [
+				_('Download the current NordVPN Easy log collected from system logread.')
+			]),
+			E('div', { 'class': 'cbi-section' }, [
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title' }, [ _('Log File') ]),
+					E('div', { 'class': 'cbi-value-field' }, [
+						E('button', {
+							'class': 'cbi-button cbi-button-apply',
+							'type': 'button',
+							'click': ui.createHandlerFn(this, function(ev) {
+								var button = ev.currentTarget;
+
+								button.disabled = true;
+
+								return fs.exec('/etc/init.d/nordvpn-easy', [ 'diagnostics_log' ]).then(function(res) {
+									var content = res.stdout || '';
+									var message = res.stderr ? res.stderr.trim() : '';
+
+									if (res.code !== 0) {
+										ui.addNotification(null, E('p', _(
+											'Log export failed with exit code %d: %s'
+										).format(res.code, message || _('Unknown error.'))), 'error');
+										return;
+									}
+
+									if (!content.trim()) {
+										ui.addNotification(null, E('p', _('No NordVPN Easy logs are currently available.')), 'info');
+										return;
+									}
+
+									downloadLogFile(content);
+								}).catch(function(err) {
+									ui.addNotification(null, E('p', _('Log export failed: ') + err.message), 'error');
+								}).finally(function() {
+									button.disabled = false;
+								});
+							})
+						}, [ _('Download Log') ])
+					])
+				])
+			])
+		]);
+	}
+});

--- a/openwrt-packages/luci-app-nordvpn-easy/root/usr/share/luci/menu.d/luci-app-nordvpn-easy.json
+++ b/openwrt-packages/luci-app-nordvpn-easy/root/usr/share/luci/menu.d/luci-app-nordvpn-easy.json
@@ -21,5 +21,13 @@
 			"type": "view",
 			"path": "nordvpn-easy/advanced"
 		}
+	},
+	"admin/services/nordvpn-easy/diagnostics": {
+		"title": "Diagnostics",
+		"order": 30,
+		"action": {
+			"type": "view",
+			"path": "nordvpn-easy/diagnostics"
+		}
 	}
 }

--- a/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
@@ -12,13 +12,14 @@ RUNTIME_CONFIG='/var/etc/nordvpn-easy.conf'
 CORE_SCRIPT='/usr/libexec/nordvpn-easy/core.sh'
 CRON_PATH='/etc/cron.d/nordvpn-easy'
 HOTPLUG_PATH='/etc/hotplug.d/iface/95-nordvpn-easy'
-EXTRA_COMMANDS='setup check rotate refresh_countries refresh_countries_force public_ip install_hooks remove_hooks disable_runtime render_runtime_config'
+EXTRA_COMMANDS='setup check rotate refresh_countries refresh_countries_force public_ip diagnostics_log install_hooks remove_hooks disable_runtime render_runtime_config'
 EXTRA_HELP='  setup                 Run setup immediately
   check                 Run one health check immediately
   rotate                Force server rotation immediately
   refresh_countries     Refresh the cached NordVPN country list
   refresh_countries_force Force-refresh the cached NordVPN country list
   public_ip             Print the current public IP
+  diagnostics_log       Print filtered NordVPN Easy log output
   install_hooks         Install cron and hotplug hooks
   remove_hooks          Remove cron and hotplug hooks
   disable_runtime       Disable the VPN interface and remove hooks
@@ -281,6 +282,15 @@ refresh_countries_force() {
 
 public_ip() {
 	run_core_action public_ip
+}
+
+diagnostics_log() {
+	command -v logread >/dev/null 2>&1 || {
+		log_service_error "logread command not found"
+		return 1
+	}
+
+	logread -e "$SERVICE_NAME"
 }
 
 disable_runtime() {

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -60,6 +60,7 @@ IP19='209.244.0.4'
 
 log () {
   printf '*** %s ***\n' "$*"
+  command -v logger >/dev/null 2>&1 && logger -t 'nordvpn-easy' "$*"
 }
 
 usage () {
@@ -148,6 +149,11 @@ ensure_vpn_interface_enabled () {
 
   /etc/init.d/network reload || {
     log "ERROR: NETWORK RELOAD FAILED WHILE ENABLING $VPN_IF"
+    return 1
+  }
+
+  ifup "$VPN_IF" || {
+    log "ERROR: IFUP FAILED WHILE ENABLING $VPN_IF"
     return 1
   }
 }


### PR DESCRIPTION
Add a LuCI diagnostics view (diagnostics.js) and menu entry to download filtered NordVPN Easy logs. Implement diagnostics_log in the init script to export logread output for the service. Enhance core.sh log() to also send messages to syslog via logger, and call ifup when enabling the VPN interface to improve reliability during interface bring-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added Diagnostics page accessible from the application menu. Users can now download system logs directly for troubleshooting and support purposes. Downloaded files include auto-generated timestamps for easy organization.

**Bug Fixes**
- Enhanced system logging to capture diagnostic information more reliably.
- Improved VPN interface handling for more robust connectivity management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->