### PR TITLE
Improve server switching reliability and real-world VPN country verification

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -122,8 +122,12 @@ function setVpnStatusIndicator(state, label) {
 		break;
 	}
 
-	statusEl.innerHTML = '<span style="display:inline-block;width:0.75rem;height:0.75rem;border-radius:50%;background:%s;vertical-align:middle;margin-right:0.45rem;"></span>%s'
-		.format(color, label);
+	statusEl.replaceChildren(
+		E('span', {
+			'style': 'display:inline-block;width:0.75rem;height:0.75rem;border-radius:50%;background:' + color + ';vertical-align:middle;margin-right:0.45rem;'
+		}),
+		document.createTextNode(label)
+	);
 }
 
 function updateOperationStatus() {

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -9,6 +9,8 @@
 var COUNTRIES_CACHE_PATH = '/tmp/nordvpn-easy-countries.json';
 var OPERATION_STATUS_ID = 'nordvpn-easy-operation-status';
 var PUBLIC_IP_STATUS_ID = 'nordvpn-easy-public-ip-status';
+var PUBLIC_COUNTRY_STATUS_ID = 'nordvpn-easy-public-country-status';
+var COUNTRY_MATCH_STATUS_ID = 'nordvpn-easy-country-match-status';
 var VPN_STATUS_ID = 'nordvpn-easy-vpn-status';
 var ENABLED_FIELD_ID = 'cbid.nordvpn_easy.main.enabled';
 var TOKEN_FIELD_ID = 'cbid.nordvpn_easy.main.nordvpn_token';
@@ -16,6 +18,8 @@ var COUNTRY_FIELD_ID = 'cbid.nordvpn_easy.main.vpn_country';
 var COUNTRY_REFRESH_BUTTON_ID = 'cbid.nordvpn_easy.main.vpn_country.refresh';
 var pendingOperationLabel = '';
 var currentOperationStatus = 'idle';
+var appliedCountryCode = '';
+var currentPublicCountry = '';
 
 function parseCountries(countriesRaw) {
 	var countries = [];
@@ -80,6 +84,10 @@ function formatActionsLabel(actions) {
 	return actions.map(humanizeAction).join(' + ');
 }
 
+function normalizeCountryCode(value) {
+	return String(value || '').trim().toUpperCase();
+}
+
 function setSetupControlsDisabled(disabled) {
 	[
 		ENABLED_FIELD_ID,
@@ -130,6 +138,69 @@ function setVpnStatusIndicator(state, label) {
 	);
 }
 
+function setCountryMatchIndicator(state, label) {
+	var statusEl = document.getElementById(COUNTRY_MATCH_STATUS_ID);
+	var color;
+
+	if (!statusEl)
+		return;
+
+	switch (state) {
+	case 'match':
+		color = '#2ea043';
+		break;
+	case 'checking':
+	case 'automatic':
+		color = '#d29922';
+		break;
+	case 'unavailable':
+	case 'inactive':
+		color = '#8c959f';
+		break;
+	default:
+		color = '#cf222e';
+		break;
+	}
+
+	statusEl.replaceChildren(
+		E('span', {
+			'style': 'display:inline-block;width:0.75rem;height:0.75rem;border-radius:50%;background:' + color + ';vertical-align:middle;margin-right:0.45rem;'
+		}),
+		document.createTextNode(label)
+	);
+}
+
+function updateCountryMatchStatus() {
+	var enabledEl = document.getElementById(ENABLED_FIELD_ID);
+	var busyAction;
+	var expectedCountry = normalizeCountryCode(appliedCountryCode);
+	var actualCountry = normalizeCountryCode(currentPublicCountry);
+
+	if (currentOperationStatus.indexOf('busy:') === 0) {
+		busyAction = currentOperationStatus.substring(5);
+
+		if (busyAction !== 'refresh_countries')
+			return setCountryMatchIndicator('checking', _('Checking'));
+	}
+	else if (currentOperationStatus === 'busy') {
+		return setCountryMatchIndicator('checking', _('Checking'));
+	}
+
+	if (enabledEl && !enabledEl.checked)
+		return setCountryMatchIndicator('inactive', _('Inactive'));
+
+	if (!expectedCountry)
+		return setCountryMatchIndicator('automatic', _('Automatic'));
+
+	if (!actualCountry)
+		return setCountryMatchIndicator('unavailable', _('Unavailable'));
+
+	if (actualCountry === expectedCountry)
+		return setCountryMatchIndicator('match', _('Match (%s)').format(actualCountry));
+
+	setCountryMatchIndicator('mismatch', _('Mismatch (%s)').format(actualCountry));
+}
+
 function updateOperationStatus() {
 	return fs.exec('/etc/init.d/nordvpn-easy', [ 'operation_status' ]).then(function(res) {
 		var raw = res.stdout ? res.stdout.trim() : '';
@@ -138,6 +209,7 @@ function updateOperationStatus() {
 		if (res.code !== 0) {
 			currentOperationStatus = 'unknown';
 			setOperationStatusText(_('Unknown'), false);
+			updateCountryMatchStatus();
 			return;
 		}
 
@@ -146,29 +218,35 @@ function updateOperationStatus() {
 		if (raw.indexOf('busy:') === 0) {
 			action = raw.substring(5);
 			setOperationStatusText(_('Applying (%s)...').format(humanizeAction(action)), true);
+			updateCountryMatchStatus();
 			return;
 		}
 
 		if (raw === 'busy') {
 			setOperationStatusText(_('Applying...'), true);
+			updateCountryMatchStatus();
 			return;
 		}
 
 		if (pendingOperationLabel) {
 			setOperationStatusText(_('Applying (%s)...').format(humanizeAction(pendingOperationLabel)), true);
+			updateCountryMatchStatus();
 			return;
 		}
 
 		setOperationStatusText(_('Idle'), false);
+		updateCountryMatchStatus();
 	}).catch(function() {
 		currentOperationStatus = pendingOperationLabel ? ('busy:' + pendingOperationLabel) : 'unknown';
 
 		if (pendingOperationLabel) {
 			setOperationStatusText(_('Applying (%s)...').format(humanizeAction(pendingOperationLabel)), true);
+			updateCountryMatchStatus();
 			return;
 		}
 
 		setOperationStatusText(_('Unknown'), false);
+		updateCountryMatchStatus();
 	});
 }
 
@@ -282,6 +360,29 @@ function updatePublicIp() {
 	});
 }
 
+function updatePublicCountry() {
+	return fs.exec('/etc/init.d/nordvpn-easy', [ 'public_country' ]).then(function(res) {
+		var statusEl = document.getElementById(PUBLIC_COUNTRY_STATUS_ID);
+		var publicCountry = normalizeCountryCode(res.stdout ? res.stdout.trim() : '');
+
+		currentPublicCountry = (res.code === 0 && publicCountry) ? publicCountry : '';
+
+		if (statusEl)
+			statusEl.textContent = currentPublicCountry || _('Unavailable');
+
+		updateCountryMatchStatus();
+	}).catch(function() {
+		var statusEl = document.getElementById(PUBLIC_COUNTRY_STATUS_ID);
+
+		currentPublicCountry = '';
+
+		if (statusEl)
+			statusEl.textContent = _('Unavailable');
+
+		updateCountryMatchStatus();
+	});
+}
+
 function runServiceAction(action) {
 	return fs.exec('/etc/init.d/nordvpn-easy', [ action ]).then(function(res) {
 		var lines = [];
@@ -348,6 +449,7 @@ return view.extend({
 
 		this.initialEnabled = (uci.get('nordvpn_easy', 'main', 'enabled') !== '0');
 		this.initialCountry = currentCountry;
+		appliedCountryCode = currentCountry;
 
 		m = new form.Map('nordvpn_easy', _('NordVPN Easy'),
 			_('Configure the minimum settings required to connect NordVPN Easy.'));
@@ -378,6 +480,18 @@ return view.extend({
 			return '<span id="%s">%s</span>'.format(PUBLIC_IP_STATUS_ID, _('Collecting data...'));
 		};
 
+		o = s.option(form.DummyValue, '_public_country', _('Public Country'));
+		o.rawhtml = true;
+		o.cfgvalue = function() {
+			return '<span id="%s">%s</span>'.format(PUBLIC_COUNTRY_STATUS_ID, _('Collecting data...'));
+		};
+
+		o = s.option(form.DummyValue, '_country_match', _('Country Match'));
+		o.rawhtml = true;
+		o.cfgvalue = function() {
+			return '<span id="%s">%s</span>'.format(COUNTRY_MATCH_STATUS_ID, _('Checking'));
+		};
+
 		o = s.option(form.Value, 'nordvpn_token', _('NordVPN Token'));
 		o.password = true;
 		o.rmempty = false;
@@ -402,6 +516,10 @@ return view.extend({
 			}, 5);
 
 			poll.add(function() {
+				return updatePublicCountry();
+			}, 15);
+
+			poll.add(function() {
 				return updateOperationStatus();
 			}, 2);
 
@@ -412,6 +530,7 @@ return view.extend({
 			updateOperationStatus();
 			updateVpnStatus();
 			updatePublicIp();
+			updatePublicCountry();
 			return node;
 		});
 	},
@@ -460,6 +579,7 @@ return view.extend({
 
 						this.initialEnabled = currentEnabled;
 						this.initialCountry = currentCountry;
+						appliedCountryCode = currentCountry;
 
 						if (!previousEnabled && currentEnabled) {
 							actions = [ 'setup', 'install_hooks' ];

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -417,71 +417,101 @@ return view.extend({
 		var previousCountry = this.initialCountry || '';
 
 		return this.handleSave(ev).then(L.bind(function() {
-			if (this._uciAppliedHandler)
-				document.removeEventListener('uci-applied', this._uciAppliedHandler);
-
-			this._uciAppliedHandler = L.bind(function() {
-				document.removeEventListener('uci-applied', this._uciAppliedHandler);
-				this._uciAppliedHandler = null;
-
-				uci.unload('nordvpn_easy');
-				uci.load('nordvpn_easy').then(L.bind(function() {
-					var currentEnabled = (uci.get('nordvpn_easy', 'main', 'enabled') !== '0');
-					var currentCountry = uci.get('nordvpn_easy', 'main', 'vpn_country') || '';
-					var actions = [];
-					var successMessage = '';
-
-					this.initialEnabled = currentEnabled;
-					this.initialCountry = currentCountry;
-
-					if (!previousEnabled && currentEnabled) {
-						actions = [ 'setup', 'install_hooks' ];
-						successMessage = _('NordVPN Easy enabled: setup completed and hooks installed.');
+			return new Promise(L.bind(function(resolve, reject) {
+				var settled = false;
+				var cleanup = L.bind(function() {
+					if (this._uciAppliedHandler) {
+						document.removeEventListener('uci-applied', this._uciAppliedHandler);
+						this._uciAppliedHandler = null;
 					}
-					else if (previousEnabled && !currentEnabled) {
-						actions = [ 'disable_runtime' ];
-						successMessage = _('NordVPN Easy disabled: VPN interface stopped and hooks removed.');
-					}
-					else if (currentEnabled && previousCountry !== currentCountry) {
-						actions = [ 'setup' ];
-						successMessage = _('Server country updated: VPN server synchronized.');
-					}
-
-					if (!actions.length) {
-						pendingOperationLabel = '';
-						updateOperationStatus();
+				}, this);
+				var finishResolve = function(value) {
+					if (settled)
 						return;
-					}
 
-					pendingOperationLabel = formatActionsLabel(actions);
-					currentOperationStatus = 'busy:' + pendingOperationLabel;
-					setVpnStatusIndicator('activating', _('Activating'));
-					setOperationStatusText(_('Applying (%s)...').format(pendingOperationLabel), true);
+					settled = true;
+					cleanup();
+					resolve(value);
+				};
+				var finishReject = function(err) {
+					if (settled)
+						return;
 
-					return runServiceActions(actions).then(function(results) {
-						var failures = summarizeActionFailures(results);
+					settled = true;
+					cleanup();
+					reject(err);
+				};
 
-						if (failures) {
-							ui.addNotification(null, E('p', failures), 'error');
-							return;
+				cleanup();
+
+				this._uciAppliedHandler = L.bind(function() {
+					Promise.resolve().then(function() {
+						uci.unload('nordvpn_easy');
+						return uci.load('nordvpn_easy');
+					}).then(L.bind(function() {
+						var currentEnabled = (uci.get('nordvpn_easy', 'main', 'enabled') !== '0');
+						var currentCountry = uci.get('nordvpn_easy', 'main', 'vpn_country') || '';
+						var actions = [];
+						var successMessage = '';
+
+						this.initialEnabled = currentEnabled;
+						this.initialCountry = currentCountry;
+
+						if (!previousEnabled && currentEnabled) {
+							actions = [ 'setup', 'install_hooks' ];
+							successMessage = _('NordVPN Easy enabled: setup completed and hooks installed.');
+						}
+						else if (previousEnabled && !currentEnabled) {
+							actions = [ 'disable_runtime' ];
+							successMessage = _('NordVPN Easy disabled: VPN interface stopped and hooks removed.');
+						}
+						else if (currentEnabled && previousCountry !== currentCountry) {
+							actions = [ 'setup' ];
+							successMessage = _('Server country updated: VPN server synchronized.');
 						}
 
-						ui.addNotification(null, E('p', successMessage), 'info');
+						if (!actions.length) {
+							pendingOperationLabel = '';
+							return updateOperationStatus();
+						}
+
+						pendingOperationLabel = formatActionsLabel(actions);
+						currentOperationStatus = 'busy:' + pendingOperationLabel;
+						setVpnStatusIndicator('activating', _('Activating'));
+						setOperationStatusText(_('Applying (%s)...').format(pendingOperationLabel), true);
+
+						return runServiceActions(actions).then(function(results) {
+							var failures = summarizeActionFailures(results);
+
+							if (failures) {
+								ui.addNotification(null, E('p', failures), 'error');
+								return;
+							}
+
+							ui.addNotification(null, E('p', successMessage), 'info');
+						});
+					}, this)).then(function(value) {
+						finishResolve(value);
 					}).catch(function(err) {
-						ui.addNotification(null, E('p', _('Automatic runtime sync failed: ') + err.message), 'error');
+						var message = (err && err.message) ? err.message : String(err);
+
+						ui.addNotification(null, E('p', _('Automatic runtime sync failed: ') + message), 'error');
+						finishReject(err);
 					}).finally(function() {
 						pendingOperationLabel = '';
 						updateOperationStatus();
 					});
-				}, this));
-			}, this);
+				}, this);
 
-			document.addEventListener('uci-applied', this._uciAppliedHandler);
-			pendingOperationLabel = _('configuration');
-			currentOperationStatus = 'busy:configuration';
-			setVpnStatusIndicator('activating', _('Activating'));
-			setOperationStatusText(_('Applying configuration...'), true);
-			ui.changes.apply(mode == '0');
+				document.addEventListener('uci-applied', this._uciAppliedHandler);
+				pendingOperationLabel = _('configuration');
+				currentOperationStatus = 'busy:configuration';
+				setVpnStatusIndicator('activating', _('Activating'));
+				setOperationStatusText(_('Applying configuration...'), true);
+				Promise.resolve(ui.changes.apply(mode == '0')).catch(function(err) {
+					finishReject(err);
+				});
+			}, this));
 		}, this));
 	}
 });

--- a/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
@@ -13,13 +13,14 @@ CORE_SCRIPT='/usr/libexec/nordvpn-easy/core.sh'
 CRON_PATH='/etc/cron.d/nordvpn-easy'
 HOTPLUG_PATH='/etc/hotplug.d/iface/95-nordvpn-easy'
 LOCK_DIR='/tmp/nordvpn-easy.lock'
-EXTRA_COMMANDS='setup check rotate refresh_countries refresh_countries_force public_ip operation_status vpn_status diagnostics_log install_hooks remove_hooks disable_runtime render_runtime_config'
+EXTRA_COMMANDS='setup check rotate refresh_countries refresh_countries_force public_ip public_country operation_status vpn_status diagnostics_log install_hooks remove_hooks disable_runtime render_runtime_config'
 EXTRA_HELP='  setup                 Run setup immediately
   check                 Run one health check immediately
   rotate                Force server rotation immediately
   refresh_countries     Refresh the cached NordVPN country list
   refresh_countries_force Force-refresh the cached NordVPN country list
   public_ip             Print the current public IP
+  public_country        Print the detected country code for the current public IP
   operation_status      Print whether a NordVPN Easy operation is running
   vpn_status            Print VPN runtime status (active/activating/inactive)
   diagnostics_log       Print filtered NordVPN Easy log output
@@ -318,6 +319,10 @@ refresh_countries_force() {
 
 public_ip() {
 	run_core_action public_ip
+}
+
+public_country() {
+	run_core_action public_country
 }
 
 operation_status() {

--- a/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
@@ -376,6 +376,14 @@ vpn_status() {
 			printf '%s\n' 'active'
 			return 0
 		fi
+
+		if ifstatus "$cfg_vpn_if" 2>/dev/null | jq -er '.up == false' >/dev/null 2>&1; then
+			printf '%s\n' 'inactive'
+			return 0
+		fi
+
+		printf '%s\n' 'inactive'
+		return 0
 	fi
 
 	if ip link show dev "$cfg_vpn_if" >/dev/null 2>&1; then

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -26,6 +26,7 @@ COUNTRIES_CACHE_TS_FILE='/tmp/nordvpn-easy-countries.timestamp'
 COUNTRIES_CACHE_TTL="${COUNTRIES_CACHE_TTL:-86400}"
 NORDVPN_API='https://api.nordvpn.com/v1'
 COUNTRIES_URL="${NORDVPN_API}/servers/countries"
+PUBLIC_COUNTRY_API='https://api.country.is'
 SERVER_RECOMMENDATIONS_URL_BASE="${NORDVPN_API}/servers/recommendations?filters[servers_technologies][identifier]=wireguard_udp&limit=10"
 CREDENTIALS_URL="${NORDVPN_API}/users/services/credentials"
 DEFAULT_CONFIG_FILE='/var/etc/nordvpn-easy.conf'
@@ -36,6 +37,7 @@ RESOLVED_COUNTRY_CODE=''
 CONFIG_PATH=''
 CONFIG_PATH_REQUIRED=0
 LOCK_ACQUIRED=0
+PUBLIC_COUNTRY_VERIFIED=0
 
 # List of IPs to randomly ping
 IP0='8.8.8.8'
@@ -66,7 +68,7 @@ log () {
 
 usage () {
   cat <<EOF
-Usage: $0 [check|setup|rotate|refresh_countries|refresh_countries_force|public_ip|run|help] [config_file]
+Usage: $0 [check|setup|rotate|refresh_countries|refresh_countries_force|public_ip|public_country|run|help] [config_file]
 
 Commands:
   check   Run one VPN health-check cycle (default)
@@ -75,6 +77,7 @@ Commands:
   refresh_countries  Refresh the cached NordVPN country list if needed
   refresh_countries_force  Force-refresh the cached NordVPN country list
   public_ip  Print the current public IP as seen from the router
+  public_country  Print the detected country code for the current public IP
   run     Backward-compatible alias for check
   help    Show this message
 
@@ -392,6 +395,10 @@ valid_public_ip () {
   printf '%s' "$1" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$|^[0-9A-Fa-f:]+$'
 }
 
+valid_country_code () {
+  printf '%s' "$1" | grep -Eq '^[A-Z]{2}$'
+}
+
 get_public_ip () {
   for PUBLIC_IP_URL in \
     'https://api.ipify.org' \
@@ -409,6 +416,63 @@ get_public_ip () {
 
   log 'ERROR: COULD NOT RETRIEVE PUBLIC IP'
   return 1
+}
+
+lookup_public_country_by_ip () {
+  LOOKUP_IP="$1"
+
+  [ -n "$LOOKUP_IP" ] || {
+    log 'ERROR: PUBLIC IP IS EMPTY - CANNOT LOOK UP COUNTRY'
+    return 1
+  }
+
+  PUBLIC_COUNTRY=$(curl -fsS --connect-timeout 5 --max-time 10 "${PUBLIC_COUNTRY_API}/${LOOKUP_IP}" 2>/dev/null | jq -er '.country // empty' 2>/dev/null) || {
+    log "ERROR: COULD NOT LOOK UP COUNTRY FOR PUBLIC IP $LOOKUP_IP"
+    return 1
+  }
+
+  PUBLIC_COUNTRY=$(printf '%s' "$PUBLIC_COUNTRY" | tr '[:lower:]' '[:upper:]')
+  valid_country_code "$PUBLIC_COUNTRY" || {
+    log "ERROR: INVALID COUNTRY LOOKUP RESPONSE FOR PUBLIC IP $LOOKUP_IP"
+    return 1
+  }
+
+  printf '%s\n' "$PUBLIC_COUNTRY"
+}
+
+get_public_country () {
+  PUBLIC_IP=$(get_public_ip) || return 1
+  lookup_public_country_by_ip "$PUBLIC_IP"
+}
+
+verify_public_country_selection () {
+  PUBLIC_COUNTRY_VERIFIED=1
+
+  PUBLIC_IP=$(get_public_ip) || {
+    log 'WARNING: COULD NOT RETRIEVE PUBLIC IP FOR COUNTRY VERIFICATION'
+    return 0
+  }
+
+  PUBLIC_COUNTRY=$(lookup_public_country_by_ip "$PUBLIC_IP") || {
+    log "WARNING: COULD NOT GEOLOCATE PUBLIC IP $PUBLIC_IP"
+    return 0
+  }
+
+  if [ -z "$VPN_COUNTRY" ]; then
+    log "Public IP verification: $PUBLIC_IP geolocates to $PUBLIC_COUNTRY with automatic country selection"
+    return 0
+  fi
+
+  resolve_country_filter || {
+    log "WARNING: COULD NOT RESOLVE SELECTED COUNTRY '$VPN_COUNTRY' FOR PUBLIC IP VERIFICATION"
+    return 0
+  }
+
+  if [ "$PUBLIC_COUNTRY" = "$RESOLVED_COUNTRY_CODE" ]; then
+    log "Public IP verification passed: $PUBLIC_IP geolocates to $PUBLIC_COUNTRY and matches selected country $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
+  else
+    log "WARNING: Public IP verification mismatch: $PUBLIC_IP geolocates to $PUBLIC_COUNTRY while selected country is $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
+  fi
 }
 
 resolve_country_filter () {
@@ -696,6 +760,7 @@ change_vpn_server () {
     if ping_interface "$VPN_IF"; then
       rm -f "$SERVER_CANDIDATES_FILE"
       log 'VPN connection restored'
+      verify_public_country_selection
       return 0
     fi
 
@@ -854,7 +919,7 @@ ACTION='check'
 
 if [ $# -gt 0 ]; then
   case "$1" in
-    check|setup|rotate|refresh_countries|refresh_countries_force|public_ip|run|help)
+    check|setup|rotate|refresh_countries|refresh_countries_force|public_ip|public_country|run|help)
       ACTION="$1"
       shift
       ;;
@@ -887,6 +952,12 @@ if [ "$ACTION" = 'public_ip' ]; then
   exit $?
 fi
 
+if [ "$ACTION" = 'public_country' ]; then
+  require_commands || exit 1
+  get_public_country
+  exit $?
+fi
+
 require_commands || exit 1
 
 log "Executing action '$ACTION' for VPN interface $VPN_IF"
@@ -912,7 +983,7 @@ case "$ACTION" in
     bootstrap_if_needed && check_once
     ;;
   setup)
-    bootstrap_if_needed && sync_server_selection && log 'NordVPN configuration is ready'
+    bootstrap_if_needed && sync_server_selection && { [ "$PUBLIC_COUNTRY_VERIFIED" -eq 1 ] || verify_public_country_selection; } && log 'NordVPN configuration is ready'
     ;;
   rotate)
     rotate_action

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -141,7 +141,7 @@ acquire_lock () {
     LOCK_PID=$(cat "$LOCK_PID_FILE" 2>/dev/null)
     if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
       log "Execution lock is already held by PID $LOCK_PID"
-      return 1
+      return 2
     fi
   fi
 
@@ -889,12 +889,18 @@ require_commands || exit 1
 log "Executing action '$ACTION' for VPN interface $VPN_IF"
 
 # Intentionally exit 0 on lock contention so cron/hotplug do not log an error when another instance already holds the lock.
-if ! acquire_lock; then
-  if lock_contention_is_nonfatal; then
+acquire_lock
+LOCK_STATUS=$?
+if [ "$LOCK_STATUS" -ne 0 ]; then
+  if [ "$LOCK_STATUS" -eq 2 ] && lock_contention_is_nonfatal; then
     exit 0
   fi
 
-  log "ERROR: ACTION '$ACTION' ABORTED BECAUSE ANOTHER NORDVPN-EASY OPERATION IS STILL RUNNING"
+  if [ "$LOCK_STATUS" -eq 2 ]; then
+    log "ERROR: ACTION '$ACTION' ABORTED BECAUSE ANOTHER NORDVPN-EASY OPERATION IS STILL RUNNING"
+  else
+    log "ERROR: ACTION '$ACTION' FAILED TO ACQUIRE EXECUTION LOCK AT $LOCK_DIR"
+  fi
   exit 1
 fi
 

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -673,12 +673,15 @@ change_vpn_server () {
     log "VPN server changed to $HOST_NAME ( $SERVER_IP )"
 
     if [ "$1" = 'reload' ]; then
-      /etc/init.d/network reload || {
+      log "Cycling VPN interface $VPN_IF to apply the new peer configuration"
+      ifdown "$VPN_IF" >/dev/null 2>&1 || true
+      sleep "$INTERFACE_RESTART_DELAY"
+      ifup "$VPN_IF" || {
         rm -f "$SERVER_CANDIDATES_FILE"
-        log 'ERROR: NETWORK RELOAD FAILED'
+        log "ERROR: IFUP FAILED AFTER CHANGING VPN SERVER ON $VPN_IF"
         return 1
       }
-      log "Waiting ${POST_RESTART_DELAY}s after network reload before validating VPN connectivity"
+      log "Waiting ${POST_RESTART_DELAY}s after cycling $VPN_IF before validating VPN connectivity"
     else
       /etc/init.d/network restart || {
         rm -f "$SERVER_CANDIDATES_FILE"


### PR DESCRIPTION
- **Wait for post-apply runtime sync in LuCI setup**
- **No-op: vpn_status already handles down interfaces correctly**
- **Differentiate lock contention from lock acquisition failures**
- **Fix LuCI VPN status badge rendering**
- **Cycle wg0 when applying a new NordVPN server**
- **Add public country verification and match status**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic public country detection displaying your geolocation based on your public IP address.
  * Introduced country match status indicator showing whether your detected public location matches your configured VPN country selection.

* **Improvements**
  * Enhanced VPN status detection with improved reliability and clearer visual indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->