### PR TITLE
fix(luci): improve Country Match reliability and public country updates

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -517,7 +517,7 @@ return view.extend({
 
 			poll.add(function() {
 				return updatePublicCountry();
-			}, 15);
+			}, 300);
 
 			poll.add(function() {
 				return updateOperationStatus();

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -18,6 +18,7 @@ var COUNTRY_FIELD_ID = 'cbid.nordvpn_easy.main.vpn_country';
 var COUNTRY_REFRESH_BUTTON_ID = 'cbid.nordvpn_easy.main.vpn_country.refresh';
 var pendingOperationLabel = '';
 var currentOperationStatus = 'idle';
+var appliedEnabled = true;
 var appliedCountryCode = '';
 var currentPublicCountry = '';
 
@@ -86,6 +87,18 @@ function formatActionsLabel(actions) {
 
 function normalizeCountryCode(value) {
 	return String(value || '').trim().toUpperCase();
+}
+
+function getEnabledCheckboxElement() {
+	var fieldEl = document.getElementById(ENABLED_FIELD_ID);
+
+	if (!fieldEl)
+		return null;
+
+	if (fieldEl.matches && fieldEl.matches('input[type="checkbox"]'))
+		return fieldEl;
+
+	return fieldEl.querySelector ? fieldEl.querySelector('input[type="checkbox"]') : null;
 }
 
 function setSetupControlsDisabled(disabled) {
@@ -171,7 +184,6 @@ function setCountryMatchIndicator(state, label) {
 }
 
 function updateCountryMatchStatus() {
-	var enabledEl = document.getElementById(ENABLED_FIELD_ID);
 	var busyAction;
 	var expectedCountry = normalizeCountryCode(appliedCountryCode);
 	var actualCountry = normalizeCountryCode(currentPublicCountry);
@@ -186,7 +198,7 @@ function updateCountryMatchStatus() {
 		return setCountryMatchIndicator('checking', _('Checking'));
 	}
 
-	if (enabledEl && !enabledEl.checked)
+	if (!appliedEnabled)
 		return setCountryMatchIndicator('inactive', _('Inactive'));
 
 	if (!expectedCountry)
@@ -449,6 +461,7 @@ return view.extend({
 
 		this.initialEnabled = (uci.get('nordvpn_easy', 'main', 'enabled') !== '0');
 		this.initialCountry = currentCountry;
+		appliedEnabled = this.initialEnabled;
 		appliedCountryCode = currentCountry;
 
 		m = new form.Map('nordvpn_easy', _('NordVPN Easy'),
@@ -579,6 +592,7 @@ return view.extend({
 
 						this.initialEnabled = currentEnabled;
 						this.initialCountry = currentCountry;
+						appliedEnabled = currentEnabled;
 						appliedCountryCode = currentCountry;
 
 						if (!previousEnabled && currentEnabled) {

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -18,6 +18,7 @@ var COUNTRY_FIELD_ID = 'cbid.nordvpn_easy.main.vpn_country';
 var COUNTRY_REFRESH_BUTTON_ID = 'cbid.nordvpn_easy.main.vpn_country.refresh';
 var pendingOperationLabel = '';
 var currentOperationStatus = 'idle';
+var currentVpnState = '';
 var appliedEnabled = true;
 var appliedCountryCode = '';
 var currentPublicCountry = '';
@@ -266,31 +267,47 @@ function updateVpnStatus() {
 	return fs.exec('/etc/init.d/nordvpn-easy', [ 'vpn_status' ]).then(function(res) {
 		var state = res.stdout ? res.stdout.trim() : 'inactive';
 		var busyAction;
+		var previousVpnState = currentVpnState;
 
 		if (currentOperationStatus.indexOf('busy:') === 0) {
 			busyAction = currentOperationStatus.substring(5);
 
-			if (busyAction !== 'refresh_countries')
+			if (busyAction !== 'refresh_countries') {
+				currentVpnState = 'activating';
 				return setVpnStatusIndicator('activating', _('Activating'));
+			}
 		}
 		else if (currentOperationStatus === 'busy') {
+			currentVpnState = 'activating';
 			return setVpnStatusIndicator('activating', _('Activating'));
 		}
 
 		if (res.code !== 0) {
+			currentVpnState = 'inactive';
 			setVpnStatusIndicator('inactive', _('Not Active'));
 			return;
 		}
 
-		if (state === 'active')
+		if (state === 'active') {
+			currentVpnState = 'active';
 			setVpnStatusIndicator('active', _('Active'));
-		else
+
+			if (previousVpnState !== 'active')
+				updatePublicCountry();
+		}
+		else {
+			currentVpnState = 'inactive';
 			setVpnStatusIndicator('inactive', _('Not Active'));
+		}
 	}).catch(function() {
-		if (currentOperationStatus.indexOf('busy') === 0)
+		if (currentOperationStatus.indexOf('busy') === 0) {
+			currentVpnState = 'activating';
 			setVpnStatusIndicator('activating', _('Activating'));
-		else
+		}
+		else {
+			currentVpnState = 'inactive';
 			setVpnStatusIndicator('inactive', _('Not Active'));
+		}
 	});
 }
 

--- a/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
@@ -382,11 +382,6 @@ vpn_status() {
 			return 0
 		fi
 
-		if ifstatus "$cfg_vpn_if" 2>/dev/null | jq -er '.up == false' >/dev/null 2>&1; then
-			printf '%s\n' 'inactive'
-			return 0
-		fi
-
 		printf '%s\n' 'inactive'
 		return 0
 	fi

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -26,7 +26,7 @@ COUNTRIES_CACHE_TS_FILE='/tmp/nordvpn-easy-countries.timestamp'
 COUNTRIES_CACHE_TTL="${COUNTRIES_CACHE_TTL:-86400}"
 NORDVPN_API='https://api.nordvpn.com/v1'
 COUNTRIES_URL="${NORDVPN_API}/servers/countries"
-PUBLIC_COUNTRY_API='https://api.country.is'
+PUBLIC_COUNTRY_API='https://api.country.is'   # Third-party API, no auth required; returns JSON like {"country":"XX"} with an ISO country code.
 SERVER_RECOMMENDATIONS_URL_BASE="${NORDVPN_API}/servers/recommendations?filters[servers_technologies][identifier]=wireguard_udp&limit=10"
 CREDENTIALS_URL="${NORDVPN_API}/users/services/credentials"
 DEFAULT_CONFIG_FILE='/var/etc/nordvpn-easy.conf'


### PR DESCRIPTION
- **Remove redundant inactive branch from vpn_status**
- **Reduce public country polling frequency in LuCI**
- **Document country.is API usage in core config**
- **fix: use appliedEnabled state variable instead of DOM checkbox for country match**
- **fix: refresh public country immediately on VPN activation**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed VPN status detection to accurately reflect enabled/disabled configuration state.
  * Improved state synchronization between settings and displayed status across configuration changes.

* **Performance**
  * Optimized country information polling to reduce system resource usage.

* **Documentation**
  * Clarified API endpoint requirements and response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->