### PR TITLE
feat: add NordVPN manager UI and server catalog cache

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,17 +30,5 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq shellcheck
 
-      - name: Make check scripts executable
-        run: |
-          set -euo pipefail
-          chmod +x \
-            scripts/check-nordvpn-easy.sh \
-            tests/nordvpn-easy/test-schema.sh \
-            tests/nordvpn-easy/test-catalog-fixtures.sh \
-            tests/nordvpn-easy/test-common-lock.sh \
-            tests/nordvpn-easy/test-runtime.sh \
-            tests/nordvpn-easy/test-service-config.sh \
-            tests/nordvpn-easy/test-actions.sh
-
       - name: Run NordVPN Easy checks
-        run: ./scripts/check-nordvpn-easy.sh
+        run: bash ./scripts/check-nordvpn-easy.sh

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -14,6 +14,7 @@ jobs:
   checks:
     name: Static checks and fixture tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,46 @@
+name: Quality
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  checks:
+    name: Static checks and fixture tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install jq and shellcheck
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y jq shellcheck
+
+      - name: Make check scripts executable
+        run: |
+          set -euo pipefail
+          chmod +x \
+            scripts/check-nordvpn-easy.sh \
+            tests/nordvpn-easy/test-schema.sh \
+            tests/nordvpn-easy/test-catalog-fixtures.sh \
+            tests/nordvpn-easy/test-common-lock.sh \
+            tests/nordvpn-easy/test-runtime.sh \
+            tests/nordvpn-easy/test-service-config.sh \
+            tests/nordvpn-easy/test-actions.sh
+
+      - name: Run NordVPN Easy checks
+        run: ./scripts/check-nordvpn-easy.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -65,7 +65,7 @@ jobs:
           echo "PACKAGE_VERSION=${RAW}" >> "$GITHUB_ENV"
 
       - name: Cache OpenWrt SDK
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .build/openwrt-sdk
           key: openwrt-sdk-${{ runner.os }}-${{ env.OPENWRT_APK_VERSION }}-${{ env.OPENWRT_TARGET }}-${{ env.OPENWRT_SUBTARGET }}-${{ env.OPENWRT_APK_TOOLCHAIN }}
@@ -371,7 +371,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -399,7 +399,7 @@ jobs:
           echo "PACKAGE_VERSION=${RAW}" >> "$GITHUB_ENV"
 
       - name: Cache OpenWrt SDK
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .build/openwrt-sdk-opkg
           key: openwrt-sdk-${{ runner.os }}-${{ env.OPENWRT_OPKG_VERSION }}-${{ env.OPENWRT_TARGET }}-${{ env.OPENWRT_SUBTARGET }}-${{ env.OPENWRT_OPKG_TOOLCHAIN }}
@@ -728,7 +728,7 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0

--- a/openwrt-packages/luci-app-nordvpn-easy/Makefile
+++ b/openwrt-packages/luci-app-nordvpn-easy/Makefile
@@ -63,6 +63,8 @@ define Build/Prepare/$(PKG_NAME)
 	$(INSTALL_BIN) $(CURDIR)/../nordvpn-easy/files/etc/init.d/nordvpn-easy $(PKG_BUILD_DIR)/root/etc/init.d/nordvpn-easy
 	$(INSTALL_DIR) $(PKG_BUILD_DIR)/root/usr/libexec/nordvpn-easy
 	$(INSTALL_BIN) $(CURDIR)/../nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh $(PKG_BUILD_DIR)/root/usr/libexec/nordvpn-easy/core.sh
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)/root/usr/libexec/nordvpn-easy/lib
+	$(CP) $(CURDIR)/../nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/. $(PKG_BUILD_DIR)/root/usr/libexec/nordvpn-easy/lib/
 endef
 
 include $(TOPDIR)/feeds/luci/luci.mk

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-data.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-data.js
@@ -1,0 +1,110 @@
+'use strict';
+
+function normalizeCountryCode(value) {
+	return String(value || '').trim().toUpperCase();
+}
+
+function emptyServerCatalog() {
+	return {
+		country_id: '',
+		country_code: '',
+		country_name: '',
+		cached_at: null,
+		cache_ttl: null,
+		servers: []
+	};
+}
+
+function parseJson(raw, fallback) {
+	try {
+		return JSON.parse(raw || '');
+	} catch (e) {
+		return fallback;
+	}
+}
+
+function parseCountries(countriesRaw) {
+	const countries = parseJson(countriesRaw, []);
+
+	return countries.filter(function(country) {
+		return country && country.name && country.code;
+	}).sort(function(a, b) {
+		return String(a.name).localeCompare(String(b.name));
+	});
+}
+
+function parseLocalStatus(raw) {
+	const status = parseJson(raw, {});
+
+	return {
+		enabled: !!status.enabled,
+		server_selection_mode: String(status.server_selection_mode || 'auto'),
+		selected_country: normalizeCountryCode(status.selected_country || ''),
+		interface: String(status.interface || ''),
+		vpn_status: String(status.vpn_status || 'inactive'),
+		operation_status: String(status.operation_status || 'idle'),
+		connected: !!status.connected,
+		endpoint: String(status.endpoint || 'N/A'),
+		latest_handshake: String(status.latest_handshake || 'Never'),
+		latest_handshake_epoch: Number(status.latest_handshake_epoch || 0),
+		transfer_rx: String(status.transfer_rx || '0 B'),
+		transfer_rx_bytes: Number(status.transfer_rx_bytes || 0),
+		transfer_tx: String(status.transfer_tx || '0 B'),
+		transfer_tx_bytes: Number(status.transfer_tx_bytes || 0),
+		current_server_hostname: String(status.current_server_hostname || ''),
+		current_server_station: String(status.current_server_station || ''),
+		current_server_city: String(status.current_server_city || ''),
+		current_server_country: normalizeCountryCode(status.current_server_country || ''),
+		current_server_load: String(status.current_server_load || ''),
+		preferred_server_hostname: String(status.preferred_server_hostname || ''),
+		preferred_server_station: String(status.preferred_server_station || '')
+	};
+}
+
+function parseServerCatalog(raw) {
+	const catalog = parseJson(raw, emptyServerCatalog());
+
+	if (!catalog || typeof catalog !== 'object')
+		return emptyServerCatalog();
+
+	return {
+		country_id: String(catalog.country_id || ''),
+		country_code: normalizeCountryCode(catalog.country_code || ''),
+		country_name: String(catalog.country_name || ''),
+		cached_at: (catalog.cached_at != null && catalog.cached_at !== '') ? Number(catalog.cached_at) : null,
+		cache_ttl: (catalog.cache_ttl != null && catalog.cache_ttl !== '') ? Number(catalog.cache_ttl) : null,
+		servers: Array.isArray(catalog.servers) ? catalog.servers.filter(function(server) {
+			return server && server.hostname && server.station && server.public_key;
+		}).map(function(server) {
+			return {
+				hostname: String(server.hostname),
+				station: String(server.station),
+				load: String(server.load != null ? server.load : ''),
+				city: String(server.city || ''),
+				country_code: normalizeCountryCode(server.country_code || ''),
+				country_name: String(server.country_name || ''),
+				public_key: String(server.public_key || '')
+			};
+		}) : []
+	};
+}
+
+function buildServerCatalogIndex(catalog) {
+	const index = {};
+
+	catalog.servers.forEach(function(server) {
+		index[String(server.station)] = server;
+	});
+
+	return index;
+}
+
+return {
+	normalizeCountryCode: normalizeCountryCode,
+	emptyServerCatalog: emptyServerCatalog,
+	parseJson: parseJson,
+	parseCountries: parseCountries,
+	parseLocalStatus: parseLocalStatus,
+	parseServerCatalog: parseServerCatalog,
+	buildServerCatalogIndex: buildServerCatalogIndex
+};

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js
@@ -1,0 +1,82 @@
+'use strict';
+
+function humanizeAction(action) {
+	return String(action || _('operation')).replace(/_/g, ' ');
+}
+
+function formatActionsLabel(actions) {
+	return actions.map(humanizeAction).join(' + ');
+}
+
+function formatServerLabel(server) {
+	const parts = [];
+	let label;
+
+	if (server.country_name)
+		parts.push(server.country_name);
+	else if (server.country_code)
+		parts.push(server.country_code);
+
+	if (server.city)
+		parts.push(server.city);
+
+	if (server.hostname)
+		parts.push(server.hostname);
+
+	label = parts.join(' - ');
+
+	if (server.load !== '')
+		label += (label ? ' - ' : '') + _('Load %s%%').format(server.load);
+
+	return label || server.station;
+}
+
+function formatServerSummary(server) {
+	if (!server)
+		return _('Automatic / Best recommended');
+
+	return formatServerLabel(server);
+}
+
+function pluralize(value, singular, plural) {
+	return _('%d %s').format(value, value === 1 ? singular : plural);
+}
+
+function formatRelativeAge(seconds) {
+	let remaining = Math.max(0, Number(seconds || 0));
+	const days = Math.floor(remaining / 86400);
+	const hours = Math.floor((remaining % 86400) / 3600);
+	const minutes = Math.floor((remaining % 3600) / 60);
+
+	if (remaining < 5)
+		return _('just now');
+
+	if (days > 0)
+		return pluralize(days, _('day'), _('days'));
+
+	if (hours > 0)
+		return pluralize(hours, _('hour'), _('hours'));
+
+	if (minutes > 0)
+		return pluralize(minutes, _('minute'), _('minutes'));
+
+	return pluralize(Math.floor(remaining), _('second'), _('seconds'));
+}
+
+function formatRelativeTimestamp(epochSeconds) {
+	const ts = Number(epochSeconds || 0);
+
+	if (!ts)
+		return '';
+
+	return _('%s ago').format(formatRelativeAge((Date.now() / 1000) - ts));
+}
+
+return {
+	humanizeAction: humanizeAction,
+	formatActionsLabel: formatActionsLabel,
+	formatServerLabel: formatServerLabel,
+	formatServerSummary: formatServerSummary,
+	formatRelativeAge: formatRelativeAge,
+	formatRelativeTimestamp: formatRelativeTimestamp
+};

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js
@@ -44,9 +44,14 @@ function pluralize(value, singular, plural) {
 }
 
 function formatRelativeAge(seconds) {
-	let remaining = Math.max(0, Number(seconds || 0));
+	let remaining = Number(seconds || 0);
 	const parts = [];
 	let value;
+
+	if (!Number.isFinite(remaining))
+		remaining = 0;
+	else
+		remaining = Math.max(0, remaining);
 
 	if (remaining < 5)
 		return _('just now');

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js
@@ -10,6 +10,7 @@ function formatActionsLabel(actions) {
 
 function formatServerLabel(server) {
 	const parts = [];
+	const numericLoad = Number(server.load);
 	let label;
 
 	if (server.country_name)
@@ -25,8 +26,8 @@ function formatServerLabel(server) {
 
 	label = parts.join(' - ');
 
-	if (server.load !== '')
-		label += (label ? ' - ' : '') + _('Load %s%%').format(server.load);
+	if (server.load != null && server.load !== '' && Number.isFinite(numericLoad))
+		label += (label ? ' - ' : '') + _('Load %s%%').format(numericLoad);
 
 	return label || server.station;
 }
@@ -44,23 +45,35 @@ function pluralize(value, singular, plural) {
 
 function formatRelativeAge(seconds) {
 	let remaining = Math.max(0, Number(seconds || 0));
-	const days = Math.floor(remaining / 86400);
-	const hours = Math.floor((remaining % 86400) / 3600);
-	const minutes = Math.floor((remaining % 3600) / 60);
+	const parts = [];
+	let value;
 
 	if (remaining < 5)
 		return _('just now');
 
-	if (days > 0)
-		return pluralize(days, _('day'), _('days'));
+	value = Math.floor(remaining / 86400);
+	if (value > 0) {
+		parts.push(pluralize(value, _('day'), _('days')));
+		remaining -= value * 86400;
+	}
 
-	if (hours > 0)
-		return pluralize(hours, _('hour'), _('hours'));
+	value = Math.floor(remaining / 3600);
+	if (value > 0) {
+		parts.push(pluralize(value, _('hour'), _('hours')));
+		remaining -= value * 3600;
+	}
 
-	if (minutes > 0)
-		return pluralize(minutes, _('minute'), _('minutes'));
+	value = Math.floor(remaining / 60);
+	if (value > 0) {
+		parts.push(pluralize(value, _('minute'), _('minutes')));
+		remaining -= value * 60;
+	}
 
-	return pluralize(Math.floor(remaining), _('second'), _('seconds'));
+	value = Math.floor(remaining);
+	if (value > 0 || !parts.length)
+		parts.push(pluralize(value, _('second'), _('seconds')));
+
+	return _('%s ago').format(parts.slice(0, 2).join(', '));
 }
 
 function formatRelativeTimestamp(epochSeconds) {
@@ -69,7 +82,7 @@ function formatRelativeTimestamp(epochSeconds) {
 	if (!ts)
 		return '';
 
-	return _('%s ago').format(formatRelativeAge((Date.now() / 1000) - ts));
+	return formatRelativeAge((Date.now() / 1000) - ts);
 }
 
 return {

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-state.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-state.js
@@ -1,0 +1,430 @@
+'use strict';
+'require fs';
+'require nordvpn-easy/manager-data as managerData';
+'require nordvpn-easy/manager-format as managerFormat';
+'require nordvpn-easy/manager-ui as managerUI';
+'require nordvpn-easy/service as service';
+'require ui';
+'require uci';
+
+function createState() {
+	return {
+		pendingOperationLabel: '',
+		currentOperationStatus: 'idle',
+		currentPublicCountry: '',
+		appliedEnabled: false,
+		appliedCountryCode: '',
+		currentLocalStatus: managerData.parseLocalStatus('{}'),
+		currentServerCatalog: managerData.emptyServerCatalog(),
+		serverCatalogIndex: {},
+		latestServerCatalogRequestId: 0
+	};
+}
+
+function loadServerCatalog(state, country, forceRefresh) {
+	const requestId = ++state.latestServerCatalogRequestId;
+	const requestedCountry = managerData.normalizeCountryCode(country || '');
+	const extraArgs = [ country || '' ];
+
+	if (!country) {
+		state.currentServerCatalog = managerData.emptyServerCatalog();
+		state.serverCatalogIndex = {};
+		managerUI.renderServerChoices(managerUI.getSelectElement(managerUI.ids.SERVER_FIELD_ID), state.currentServerCatalog, '');
+		managerUI.updateServerSelectionState(state);
+		return Promise.resolve(state.currentServerCatalog);
+	}
+
+	if (forceRefresh)
+		extraArgs.push('1');
+
+	return service.execService('server_catalog', extraArgs).then(function(res) {
+		let message;
+		let parsedCatalog;
+
+		if (requestId !== state.latestServerCatalogRequestId || requestedCountry !== managerUI.getSelectedCountry())
+			return null;
+
+		if (res.code !== 0) {
+			message = (res.stderr || '').trim() || _('Server catalog refresh failed.');
+			throw new Error(message);
+		}
+
+		parsedCatalog = managerData.parseServerCatalog(res.stdout || '');
+		state.currentServerCatalog = parsedCatalog;
+		state.serverCatalogIndex = managerData.buildServerCatalogIndex(parsedCatalog);
+		managerUI.renderServerChoices(
+			managerUI.getSelectElement(managerUI.ids.SERVER_FIELD_ID),
+			parsedCatalog,
+			managerUI.getSelectedPreferredStation()
+		);
+		managerUI.updateServerSelectionState(state);
+		return state.currentServerCatalog;
+	});
+}
+
+function updatePublicIp() {
+	return service.execService('public_ip').then(function(res) {
+		const publicIp = res.stdout ? res.stdout.trim() : '';
+
+		managerUI.replaceStatusText(
+			managerUI.ids.PUBLIC_IP_STATUS_ID,
+			(res.code === 0 && publicIp && publicIp !== 'null' && publicIp !== 'undefined') ? publicIp : _('Unavailable')
+		);
+	}).catch(function() {
+		managerUI.replaceStatusText(managerUI.ids.PUBLIC_IP_STATUS_ID, _('Unavailable'));
+	});
+}
+
+function updatePublicCountry(state) {
+	return service.execService('public_country').then(function(res) {
+		const publicCountry = managerData.normalizeCountryCode(res.stdout ? res.stdout.trim() : '');
+
+		state.currentPublicCountry = (res.code === 0 && publicCountry) ? publicCountry : '';
+		managerUI.replaceStatusText(managerUI.ids.PUBLIC_COUNTRY_STATUS_ID, state.currentPublicCountry || _('Unavailable'));
+		managerUI.updateCountryMatchStatus(state);
+	}).catch(function() {
+		state.currentPublicCountry = '';
+		managerUI.replaceStatusText(managerUI.ids.PUBLIC_COUNTRY_STATUS_ID, _('Unavailable'));
+		managerUI.updateCountryMatchStatus(state);
+	});
+}
+
+function updateLocalStatus(state) {
+	return service.execService('status_json').then(function(res) {
+		let busyAction;
+
+		state.currentLocalStatus = service.parseExecJsonResponse(res, managerData.parseLocalStatus('{}'));
+		state.currentOperationStatus = String(state.currentLocalStatus.operation_status || 'idle');
+		state.appliedEnabled = !!state.currentLocalStatus.enabled;
+		state.appliedCountryCode = managerData.normalizeCountryCode(state.currentLocalStatus.selected_country || state.appliedCountryCode);
+
+		managerUI.replaceStatusText(managerUI.ids.CURRENT_SERVER_STATUS_ID, managerUI.currentServerSummaryFromStatus(state.currentLocalStatus));
+		managerUI.replaceStatusText(managerUI.ids.PREFERRED_SERVER_STATUS_ID, managerUI.preferredServerSummaryFromStatus(state.currentLocalStatus));
+		managerUI.replaceStatusText(managerUI.ids.ENDPOINT_STATUS_ID, state.currentLocalStatus.endpoint || _('Unavailable'));
+		managerUI.replaceStatusText(managerUI.ids.HANDSHAKE_STATUS_ID, state.currentLocalStatus.latest_handshake || _('Never'));
+		managerUI.replaceStatusText(
+			managerUI.ids.TRANSFER_STATUS_ID,
+			_('%s / %s').format(state.currentLocalStatus.transfer_rx || '0 B', state.currentLocalStatus.transfer_tx || '0 B')
+		);
+
+		if (state.currentOperationStatus.indexOf('busy:') === 0) {
+			busyAction = state.currentOperationStatus.substring(5);
+			managerUI.replaceStatusText(managerUI.ids.OPERATION_STATUS_ID, _('Applying (%s)...').format(managerFormat.humanizeAction(busyAction)));
+			managerUI.setManagerControlsDisabled(true);
+
+			if (busyAction !== 'refresh_countries' && busyAction !== 'server_catalog') {
+				managerUI.setVpnStatusIndicator('activating', _('Activating'));
+				managerUI.updateCountryMatchStatus(state);
+				managerUI.updateServerSelectionState(state);
+				return;
+			}
+		}
+		else if (state.currentOperationStatus === 'busy') {
+			managerUI.replaceStatusText(managerUI.ids.OPERATION_STATUS_ID, _('Applying...'));
+			managerUI.setVpnStatusIndicator('activating', _('Activating'));
+			managerUI.setManagerControlsDisabled(true);
+			managerUI.updateCountryMatchStatus(state);
+			managerUI.updateServerSelectionState(state);
+			return;
+		}
+
+		if (state.pendingOperationLabel) {
+			managerUI.replaceStatusText(
+				managerUI.ids.OPERATION_STATUS_ID,
+				_('Applying (%s)...').format(managerFormat.humanizeAction(state.pendingOperationLabel))
+			);
+			managerUI.setVpnStatusIndicator('activating', _('Activating'));
+			managerUI.setManagerControlsDisabled(true);
+		}
+		else if (state.currentOperationStatus !== 'busy' && state.currentOperationStatus.indexOf('busy:') !== 0) {
+			managerUI.replaceStatusText(managerUI.ids.OPERATION_STATUS_ID, _('Idle'));
+			managerUI.setManagerControlsDisabled(false);
+		}
+
+		if (state.currentLocalStatus.connected || state.currentLocalStatus.vpn_status === 'active')
+			managerUI.setVpnStatusIndicator('active', _('Connected'));
+		else
+			managerUI.setVpnStatusIndicator('inactive', _('Disconnected'));
+
+		managerUI.updateCountryMatchStatus(state);
+		managerUI.updateServerSelectionState(state);
+	}).catch(function() {
+		state.currentOperationStatus = state.pendingOperationLabel ? ('busy:' + state.pendingOperationLabel) : 'unknown';
+		managerUI.replaceStatusText(
+			managerUI.ids.OPERATION_STATUS_ID,
+			state.pendingOperationLabel ? _('Applying (%s)...').format(managerFormat.humanizeAction(state.pendingOperationLabel)) : _('Unknown')
+		);
+		managerUI.setVpnStatusIndicator(
+			state.pendingOperationLabel ? 'activating' : 'inactive',
+			state.pendingOperationLabel ? _('Activating') : _('Disconnected')
+		);
+		if (!state.pendingOperationLabel)
+			managerUI.setManagerControlsDisabled(false);
+		managerUI.updateCountryMatchStatus(state);
+		managerUI.updateServerSelectionState(state);
+	});
+}
+
+function onCountryChanged(state) {
+	const country = managerUI.getSelectedCountry();
+	const selectEl = managerUI.getSelectElement(managerUI.ids.SERVER_FIELD_ID);
+
+	if (selectEl)
+		selectEl.value = '';
+
+	if (!country) {
+		state.latestServerCatalogRequestId++;
+		state.currentServerCatalog = managerData.emptyServerCatalog();
+		state.serverCatalogIndex = {};
+		managerUI.renderServerChoices(selectEl, state.currentServerCatalog, '');
+		managerUI.updateServerSelectionState(state);
+		return Promise.resolve();
+	}
+
+	state.currentServerCatalog = managerData.emptyServerCatalog();
+	state.serverCatalogIndex = {};
+	managerUI.renderServerChoices(selectEl, state.currentServerCatalog, '');
+	managerUI.updateServerSelectionState(state);
+
+	return loadServerCatalog(state, country, false).catch(function(err) {
+		service.notifyError(err);
+	});
+}
+
+function onModeChanged(state) {
+	if (managerUI.getSelectedMode() !== 'manual') {
+		const selectEl = managerUI.getSelectElement(managerUI.ids.SERVER_FIELD_ID);
+
+		if (selectEl)
+			selectEl.value = '';
+	}
+
+	managerUI.updateServerSelectionState(state);
+}
+
+function handleRefreshServerCatalog(state, ev) {
+	const country = managerUI.getSelectedCountry();
+	const button = ev ? ev.currentTarget : managerUI.getInputElement(managerUI.ids.SERVER_REFRESH_BUTTON_ID, 'button');
+
+	if (!country) {
+		ui.addNotification(null, E('p', _('Select a country before refreshing the server catalog.')), 'warning');
+		return Promise.resolve();
+	}
+
+	if (button)
+		button.disabled = true;
+
+	ui.showModal(_('Refreshing Server List'), [
+		E('p', { class: 'spinning' }, _('Downloading the NordVPN WireGuard server catalog...'))
+	]);
+
+	return loadServerCatalog(state, country, true).then(function(catalog) {
+		if (catalog)
+			service.notifyInfo(_('Server catalog refreshed.'));
+	}).catch(function(err) {
+		service.notifyError(err);
+	}).finally(function() {
+		ui.hideModal();
+		if (button)
+			button.disabled = false;
+		managerUI.updateServerSelectionState(state);
+	});
+}
+
+function handleSaveApply(viewState, state, ev, mode) {
+	const previousEnabled = !!viewState.initialEnabled;
+	const previousCountry = viewState.initialCountry || '';
+	const previousMode = viewState.initialMode || 'auto';
+	const previousPreferredStation = viewState.initialPreferredStation || '';
+	const currentMode = managerUI.getSelectedMode();
+	const currentCountry = managerUI.getSelectedCountry();
+	const preferredStation = managerUI.getSelectedPreferredStation();
+	const preferredStationChanged = (currentMode === 'manual' && preferredStation !== previousPreferredStation);
+	const enteringManualMode = (currentMode === 'manual' && previousMode !== 'manual');
+	const selectedServer = preferredStation ? state.serverCatalogIndex[preferredStation] : null;
+	const preservingExistingManualPreference = (
+		currentMode === 'manual' &&
+		previousMode === 'manual' &&
+		!preferredStationChanged &&
+		preferredStation === previousPreferredStation &&
+		!!preferredStation
+	);
+	let confirmationPromise = Promise.resolve(true);
+
+	if (currentMode === 'manual') {
+		if (!currentCountry) {
+			service.notifyError(new Error(_('Manual mode requires a selected country.')));
+			return Promise.resolve();
+		}
+
+		if ((!preferredStation || !selectedServer) && !preservingExistingManualPreference) {
+			service.notifyError(new Error(_('Manual mode requires a valid preferred server from the current catalog.')));
+			return Promise.resolve();
+		}
+
+		if (preferredStationChanged || enteringManualMode) {
+			uci.set('nordvpn_easy', 'main', 'preferred_server_hostname', selectedServer.hostname);
+			uci.set('nordvpn_easy', 'main', 'preferred_server_station', preferredStation);
+		}
+	}
+	else {
+		uci.set('nordvpn_easy', 'main', 'preferred_server_hostname', '');
+		uci.set('nordvpn_easy', 'main', 'preferred_server_station', '');
+	}
+
+	if (previousEnabled && managerUI.getEnabledCheckboxElement() && !managerUI.getEnabledCheckboxElement().checked) {
+		confirmationPromise = managerUI.showConfirmationModal(
+			_('Disable NordVPN Easy'),
+			[
+				_('Disabling NordVPN Easy will stop the VPN interface and remove cron/hotplug hooks.'),
+				_('Your current VPN connection will be interrupted.')
+			]
+		);
+	}
+	else if (previousEnabled && (
+		previousCountry !== currentCountry ||
+		previousMode !== currentMode ||
+		(currentMode === 'manual' && previousPreferredStation !== preferredStation)
+	)) {
+		confirmationPromise = managerUI.showConfirmationModal(
+			_('Confirm Server Change'),
+			[
+				_('Applying these changes will briefly interrupt the VPN connection while NordVPN Easy reconfigures the tunnel.'),
+				currentMode === 'manual'
+					? (selectedServer
+						? _('Preferred server: %s').format(managerFormat.formatServerLabel(selectedServer))
+						: (preferredStation
+							? _('Preferred server unchanged: %s').format(preferredStation)
+							: _('Manual mode will keep the existing preferred server settings.')))
+					: _('Automatic mode will use NordVPN recommended servers.')
+			]
+		);
+	}
+
+	return confirmationPromise.then(function(confirmed) {
+		if (!confirmed)
+			return;
+
+		return viewState.handleSave(ev).then(function() {
+			return new Promise(function(resolve, reject) {
+				let settled = false;
+
+				const cleanup = function() {
+					if (viewState._uciAppliedHandler) {
+						document.removeEventListener('uci-applied', viewState._uciAppliedHandler);
+						viewState._uciAppliedHandler = null;
+					}
+				};
+
+				const finishResolve = function(value) {
+					if (settled)
+						return;
+
+					settled = true;
+					cleanup();
+					resolve(value);
+				};
+
+				const finishReject = function(err) {
+					if (settled)
+						return;
+
+					settled = true;
+					cleanup();
+					reject(err);
+				};
+
+				cleanup();
+
+				viewState._uciAppliedHandler = function() {
+					Promise.resolve().then(function() {
+						uci.unload('nordvpn_easy');
+						return uci.load('nordvpn_easy');
+					}).then(function() {
+						const enabled = (uci.get('nordvpn_easy', 'main', 'enabled') !== '0');
+						const country = managerData.normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
+						const modeValue = String(uci.get('nordvpn_easy', 'main', 'server_selection_mode') || 'auto');
+						const preferred = String(uci.get('nordvpn_easy', 'main', 'preferred_server_station') || '');
+						let actions = [];
+						let successMessage = '';
+
+						viewState.initialEnabled = enabled;
+						viewState.initialCountry = country;
+						viewState.initialMode = modeValue;
+						viewState.initialPreferredStation = preferred;
+						state.appliedEnabled = enabled;
+						state.appliedCountryCode = country;
+
+						if (!previousEnabled && enabled) {
+							actions = [ 'setup', 'install_hooks' ];
+							successMessage = _('NordVPN Easy enabled: setup completed and hooks installed.');
+						}
+						else if (previousEnabled && !enabled) {
+							actions = [ 'disable_runtime' ];
+							successMessage = _('NordVPN Easy disabled: VPN interface stopped and hooks removed.');
+						}
+						else if (enabled && (
+							previousCountry !== country ||
+							previousMode !== modeValue ||
+							(modeValue === 'manual' && previousPreferredStation !== preferred)
+						)) {
+							actions = [ 'setup' ];
+							successMessage = modeValue === 'manual'
+								? _('Manual preferred server updated and synchronized.')
+								: _('NordVPN Easy synchronized the automatic server selection.');
+						}
+
+						if (!actions.length) {
+							state.pendingOperationLabel = '';
+							updateLocalStatus(state);
+							finishResolve();
+							return;
+						}
+
+						state.pendingOperationLabel = managerFormat.formatActionsLabel(actions);
+						state.currentOperationStatus = 'busy:' + state.pendingOperationLabel;
+						updateLocalStatus(state);
+
+						service.runActions(actions).then(function() {
+							service.notifyInfo(successMessage);
+							finishResolve();
+						}).catch(function(err) {
+							service.notifyError(err);
+							finishReject(err);
+						}).finally(function() {
+							state.pendingOperationLabel = '';
+							updateLocalStatus(state);
+							updatePublicIp();
+							updatePublicCountry(state);
+						});
+					}).catch(function(err) {
+						const message = (err && err.message) ? err.message : String(err);
+
+						service.notifyError(new Error(_('Automatic runtime sync failed: ') + message));
+						finishReject(err);
+					});
+				};
+
+				document.addEventListener('uci-applied', viewState._uciAppliedHandler);
+				state.pendingOperationLabel = _('configuration');
+				state.currentOperationStatus = 'busy:configuration';
+				updateLocalStatus(state);
+				Promise.resolve(ui.changes.apply(mode === '0')).catch(function(err) {
+					finishReject(err);
+				});
+			});
+		});
+	});
+}
+
+return {
+	createState: createState,
+	loadServerCatalog: loadServerCatalog,
+	updatePublicIp: updatePublicIp,
+	updatePublicCountry: updatePublicCountry,
+	updateLocalStatus: updateLocalStatus,
+	onCountryChanged: onCountryChanged,
+	onModeChanged: onModeChanged,
+	handleRefreshServerCatalog: handleRefreshServerCatalog,
+	handleSaveApply: handleSaveApply
+};

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-ui.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-ui.js
@@ -1,0 +1,439 @@
+'use strict';
+'require nordvpn-easy/manager-data as managerData';
+'require nordvpn-easy/manager-format as managerFormat';
+'require ui';
+
+const ids = {
+	ENABLED_FIELD_ID: 'cbid.nordvpn_easy.main.enabled',
+	TOKEN_FIELD_ID: 'cbid.nordvpn_easy.main.nordvpn_token',
+	COUNTRY_FIELD_ID: 'cbid.nordvpn_easy.main.vpn_country',
+	COUNTRY_REFRESH_BUTTON_ID: 'cbid.nordvpn_easy.main.vpn_country.refresh',
+	MODE_FIELD_ID: 'cbid.nordvpn_easy.main.server_selection_mode',
+	SERVER_FIELD_ID: 'cbid.nordvpn_easy.main.preferred_server_station',
+	SERVER_REFRESH_BUTTON_ID: 'cbid.nordvpn_easy.main._refresh_servers',
+	VPN_STATUS_ID: 'nordvpn-easy-vpn-status',
+	CURRENT_SERVER_STATUS_ID: 'nordvpn-easy-current-server-status',
+	PREFERRED_SERVER_STATUS_ID: 'nordvpn-easy-preferred-server-status',
+	ENDPOINT_STATUS_ID: 'nordvpn-easy-endpoint-status',
+	HANDSHAKE_STATUS_ID: 'nordvpn-easy-handshake-status',
+	TRANSFER_STATUS_ID: 'nordvpn-easy-transfer-status',
+	OPERATION_STATUS_ID: 'nordvpn-easy-operation-status',
+	PUBLIC_IP_STATUS_ID: 'nordvpn-easy-public-ip-status',
+	PUBLIC_COUNTRY_STATUS_ID: 'nordvpn-easy-public-country-status',
+	COUNTRY_MATCH_STATUS_ID: 'nordvpn-easy-country-match-status',
+	SERVER_CATALOG_STATUS_ID: 'nordvpn-easy-server-catalog-status',
+	SERVER_SELECTION_HINT_ID: 'nordvpn-easy-server-selection-hint'
+};
+
+function getSelectElement(optionId) {
+	const frameEl = document.getElementById(optionId);
+
+	if (!frameEl)
+		return null;
+
+	if (frameEl.matches && frameEl.matches('select'))
+		return frameEl;
+
+	return frameEl.querySelector ? frameEl.querySelector('select') : null;
+}
+
+function getInputElement(optionId, selector) {
+	const fieldEl = document.getElementById(optionId);
+
+	if (!fieldEl)
+		return null;
+
+	if (!selector)
+		return fieldEl;
+
+	if (fieldEl.matches && fieldEl.matches(selector))
+		return fieldEl;
+
+	return fieldEl.querySelector ? fieldEl.querySelector(selector) : null;
+}
+
+function getEnabledCheckboxElement() {
+	return getInputElement(ids.ENABLED_FIELD_ID, 'input[type="checkbox"]');
+}
+
+function getSelectedCountry() {
+	const selectEl = getSelectElement(ids.COUNTRY_FIELD_ID);
+
+	return managerData.normalizeCountryCode(selectEl ? selectEl.value : '');
+}
+
+function getSelectedMode() {
+	const selectEl = getSelectElement(ids.MODE_FIELD_ID);
+
+	return String(selectEl ? selectEl.value : 'auto');
+}
+
+function getSelectedPreferredStation() {
+	const selectEl = getSelectElement(ids.SERVER_FIELD_ID);
+
+	return String(selectEl ? selectEl.value : '');
+}
+
+function renderCountryChoices(selectEl, countries, currentCountry) {
+	let seenCurrent = false;
+
+	if (!selectEl)
+		return;
+
+	while (selectEl.firstChild)
+		selectEl.removeChild(selectEl.firstChild);
+
+	selectEl.appendChild(E('option', { value: '' }, [ _('Automatic') ]));
+
+	countries.forEach(function(country) {
+		const value = String(country.code);
+
+		selectEl.appendChild(E('option', { value: value }, [
+			_('%s (%s)').format(country.name, value)
+		]));
+
+		if (value === currentCountry)
+			seenCurrent = true;
+	});
+
+	if (currentCountry && !seenCurrent) {
+		selectEl.appendChild(E('option', { value: currentCountry }, [
+			_('Current value: %s').format(currentCountry)
+		]));
+	}
+
+	selectEl.value = currentCountry || '';
+}
+
+function renderServerChoices(selectEl, catalog, currentStation) {
+	let seenCurrent = false;
+
+	if (!selectEl)
+		return;
+
+	while (selectEl.firstChild)
+		selectEl.removeChild(selectEl.firstChild);
+
+	selectEl.appendChild(E('option', { value: '' }, [
+		catalog.servers.length ? _('-- Select Server --') : _('No server catalog loaded')
+	]));
+
+	catalog.servers.forEach(function(server) {
+		const value = String(server.station);
+
+		selectEl.appendChild(E('option', { value: value }, [
+			managerFormat.formatServerLabel(server)
+		]));
+
+		if (value === currentStation)
+			seenCurrent = true;
+	});
+
+	if (currentStation && !seenCurrent) {
+		selectEl.appendChild(E('option', { value: currentStation }, [
+			_('Current value: %s').format(currentStation)
+		]));
+	}
+
+	selectEl.value = currentStation || '';
+}
+
+function setStatusIndicator(elementId, color, label) {
+	const statusEl = document.getElementById(elementId);
+
+	if (!statusEl)
+		return;
+
+	statusEl.replaceChildren(
+		E('span', {
+			style: 'display:inline-block;width:0.75rem;height:0.75rem;border-radius:50%;background:' + color + ';vertical-align:middle;margin-right:0.45rem;'
+		}),
+		document.createTextNode(label)
+	);
+}
+
+function setVpnStatusIndicator(state, label) {
+	let color = '#cf222e';
+
+	if (state === 'active')
+		color = '#2ea043';
+	else if (state === 'activating')
+		color = '#d29922';
+
+	setStatusIndicator(ids.VPN_STATUS_ID, color, label);
+}
+
+function setCountryMatchIndicator(state, label) {
+	let color = '#cf222e';
+
+	switch (state) {
+	case 'match':
+		color = '#2ea043';
+		break;
+	case 'checking':
+	case 'automatic':
+		color = '#d29922';
+		break;
+	case 'inactive':
+	case 'unavailable':
+		color = '#8c959f';
+		break;
+	}
+
+	setStatusIndicator(ids.COUNTRY_MATCH_STATUS_ID, color, label);
+}
+
+function replaceStatusText(elementId, value) {
+	const element = document.getElementById(elementId);
+
+	if (element)
+		element.textContent = value;
+}
+
+function currentServerSummaryFromStatus(status) {
+	if (!status || !status.current_server_station)
+		return _('Not configured');
+
+	return managerFormat.formatServerSummary({
+		hostname: status.current_server_hostname,
+		station: status.current_server_station,
+		city: status.current_server_city,
+		country_code: status.current_server_country,
+		load: status.current_server_load
+	});
+}
+
+function preferredServerSummaryFromStatus(status) {
+	if (!status)
+		return _('Automatic / Best recommended');
+
+	if (status.server_selection_mode !== 'manual')
+		return _('Automatic / Best recommended');
+
+	if (!status.preferred_server_station)
+		return _('Manual selection pending');
+
+	return managerFormat.formatServerSummary({
+		hostname: status.preferred_server_hostname,
+		station: status.preferred_server_station,
+		country_code: status.selected_country
+	});
+}
+
+function updateCountryMatchStatus(state) {
+	let busyAction;
+	const expectedCountry = managerData.normalizeCountryCode(state.appliedCountryCode);
+	const actualCountry = managerData.normalizeCountryCode(state.currentPublicCountry);
+
+	if (state.currentOperationStatus.indexOf('busy:') === 0) {
+		busyAction = state.currentOperationStatus.substring(5);
+
+		if (busyAction !== 'refresh_countries' && busyAction !== 'server_catalog')
+			return setCountryMatchIndicator('checking', _('Checking'));
+	}
+	else if (state.currentOperationStatus === 'busy') {
+		return setCountryMatchIndicator('checking', _('Checking'));
+	}
+
+	if (!state.appliedEnabled)
+		return setCountryMatchIndicator('inactive', _('Inactive'));
+
+	if (!expectedCountry)
+		return setCountryMatchIndicator('automatic', _('Automatic'));
+
+	if (!actualCountry)
+		return setCountryMatchIndicator('unavailable', _('Unavailable'));
+
+	if (actualCountry === expectedCountry)
+		return setCountryMatchIndicator('match', _('Match (%s)').format(actualCountry));
+
+	setCountryMatchIndicator('mismatch', _('Mismatch (%s)').format(actualCountry));
+}
+
+function setManagerControlsDisabled(disabled) {
+	[
+		ids.ENABLED_FIELD_ID,
+		ids.TOKEN_FIELD_ID,
+		ids.COUNTRY_FIELD_ID,
+		ids.COUNTRY_REFRESH_BUTTON_ID,
+		ids.MODE_FIELD_ID,
+		ids.SERVER_FIELD_ID,
+		ids.SERVER_REFRESH_BUTTON_ID
+	].forEach(function(id) {
+		const fieldEl = document.getElementById(id);
+		const selectEl = getSelectElement(id);
+		const inputEl = getInputElement(id, 'input,button');
+
+		if (fieldEl && fieldEl.matches && fieldEl.matches('button'))
+			fieldEl.disabled = disabled;
+
+		if (selectEl)
+			selectEl.disabled = disabled;
+
+		if (inputEl)
+			inputEl.disabled = disabled;
+	});
+
+	document.querySelectorAll('.cbi-page-actions button, .cbi-page-actions input[type="button"], .cbi-page-actions input[type="submit"]').forEach(function(el) {
+		el.disabled = disabled;
+	});
+}
+
+function updateServerCatalogStatus(state) {
+	let text;
+	let freshness = '';
+	const mode = getSelectedMode();
+	const country = getSelectedCountry();
+	const selectionHintEl = document.getElementById(ids.SERVER_SELECTION_HINT_ID);
+	const statusEl = document.getElementById(ids.SERVER_CATALOG_STATUS_ID);
+
+	if (!country) {
+		text = _('Select a country to load the manual server catalog.');
+	}
+	else if (!state.currentServerCatalog.servers.length) {
+		text = _('No server catalog loaded for %s yet.').format(country);
+	}
+	else {
+		text = _('%d servers cached for %s').format(
+			state.currentServerCatalog.servers.length,
+			state.currentServerCatalog.country_name || state.currentServerCatalog.country_code || country
+		);
+
+		if (state.currentServerCatalog.cached_at)
+			freshness = managerFormat.formatRelativeTimestamp(state.currentServerCatalog.cached_at);
+
+		if (freshness)
+			text += _(' (refreshed %s)').format(freshness);
+	}
+
+	if (statusEl)
+		statusEl.textContent = text;
+
+	if (selectionHintEl) {
+		if (mode !== 'manual')
+			selectionHintEl.textContent = _('Automatic mode uses NordVPN recommended servers for the selected country.');
+		else if (!country)
+			selectionHintEl.textContent = _('Manual mode requires a country and a preferred server.');
+		else if (!state.currentServerCatalog.servers.length)
+			selectionHintEl.textContent = _('Use "Refresh Server List" to fetch the NordVPN catalog for the selected country.');
+		else
+			selectionHintEl.textContent = _('Manual mode is rigid during health checks. Rotate updates the saved preferred server.');
+	}
+}
+
+function updateServerSelectionState(state) {
+	const mode = getSelectedMode();
+	const country = getSelectedCountry();
+	const busy = state.currentOperationStatus.indexOf('busy') === 0;
+	const selectEl = getSelectElement(ids.SERVER_FIELD_ID);
+	const refreshButton = getInputElement(ids.SERVER_REFRESH_BUTTON_ID, 'button');
+
+	updateServerCatalogStatus(state);
+
+	if (selectEl)
+		selectEl.disabled = busy || mode !== 'manual' || !country || !state.currentServerCatalog.servers.length;
+
+	if (refreshButton)
+		refreshButton.disabled = busy || !country;
+}
+
+function showConfirmationModal(title, lines) {
+	return new Promise(function(resolve) {
+		const body = [
+			E('p', {}, lines[0])
+		];
+
+		if (lines[1])
+			body.push(E('p', {}, lines[1]));
+
+		body.push(E('div', { class: 'right' }, [
+			E('button', {
+				class: 'btn',
+				click: function() {
+					ui.hideModal();
+					resolve(false);
+				}
+			}, [ _('Cancel') ]),
+			' ',
+			E('button', {
+				class: 'btn cbi-button-apply',
+				click: function() {
+					ui.hideModal();
+					resolve(true);
+				}
+			}, [ _('Apply') ])
+		]));
+
+		ui.showModal(title, body);
+	});
+}
+
+function renderStatusSection() {
+	return E('div', { class: 'table-wrapper' }, [
+		E('table', { class: 'table' }, [
+			E('tr', { class: 'tr' }, [
+				E('td', { class: 'td left', style: 'width: 30%; font-weight: bold' }, [ _('Connection') ]),
+				E('td', { class: 'td left' }, [ E('span', { id: ids.VPN_STATUS_ID }, [ _('Collecting data...') ]) ])
+			]),
+			E('tr', { class: 'tr' }, [
+				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Current Server') ]),
+				E('td', { class: 'td left', id: ids.CURRENT_SERVER_STATUS_ID }, [ _('Collecting data...') ])
+			]),
+			E('tr', { class: 'tr' }, [
+				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Preferred Server') ]),
+				E('td', { class: 'td left', id: ids.PREFERRED_SERVER_STATUS_ID }, [ _('Collecting data...') ])
+			]),
+			E('tr', { class: 'tr' }, [
+				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Endpoint') ]),
+				E('td', { class: 'td left', id: ids.ENDPOINT_STATUS_ID }, [ _('Collecting data...') ])
+			]),
+			E('tr', { class: 'tr' }, [
+				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Last WireGuard Handshake') ]),
+				E('td', { class: 'td left', id: ids.HANDSHAKE_STATUS_ID }, [ _('Collecting data...') ])
+			]),
+			E('tr', { class: 'tr' }, [
+				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Tunnel Activity (RX / TX)') ]),
+				E('td', { class: 'td left', id: ids.TRANSFER_STATUS_ID }, [ _('Collecting data...') ])
+			]),
+			E('tr', { class: 'tr' }, [
+				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Operation Status') ]),
+				E('td', { class: 'td left', id: ids.OPERATION_STATUS_ID }, [ _('Collecting data...') ])
+			]),
+			E('tr', { class: 'tr' }, [
+				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Public IP') ]),
+				E('td', { class: 'td left', id: ids.PUBLIC_IP_STATUS_ID }, [ _('Collecting data...') ])
+			]),
+			E('tr', { class: 'tr' }, [
+				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Public Country') ]),
+				E('td', { class: 'td left', id: ids.PUBLIC_COUNTRY_STATUS_ID }, [ _('Collecting data...') ])
+			]),
+			E('tr', { class: 'tr' }, [
+				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Country Match') ]),
+				E('td', { class: 'td left' }, [ E('span', { id: ids.COUNTRY_MATCH_STATUS_ID }, [ _('Checking') ]) ])
+			])
+		])
+	]);
+}
+
+return {
+	ids: ids,
+	getSelectElement: getSelectElement,
+	getInputElement: getInputElement,
+	getEnabledCheckboxElement: getEnabledCheckboxElement,
+	getSelectedCountry: getSelectedCountry,
+	getSelectedMode: getSelectedMode,
+	getSelectedPreferredStation: getSelectedPreferredStation,
+	renderCountryChoices: renderCountryChoices,
+	renderServerChoices: renderServerChoices,
+	setVpnStatusIndicator: setVpnStatusIndicator,
+	setCountryMatchIndicator: setCountryMatchIndicator,
+	replaceStatusText: replaceStatusText,
+	currentServerSummaryFromStatus: currentServerSummaryFromStatus,
+	preferredServerSummaryFromStatus: preferredServerSummaryFromStatus,
+	updateCountryMatchStatus: updateCountryMatchStatus,
+	setManagerControlsDisabled: setManagerControlsDisabled,
+	updateServerCatalogStatus: updateServerCatalogStatus,
+	updateServerSelectionState: updateServerSelectionState,
+	showConfirmationModal: showConfirmationModal,
+	renderStatusSection: renderStatusSection
+};

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
@@ -1,0 +1,130 @@
+'use strict';
+'require fs';
+'require ui';
+
+function parseJson(raw, fallback) {
+	try {
+		return JSON.parse(raw || '');
+	} catch (e) {
+		return fallback;
+	}
+}
+
+function responseMessage(res, fallback) {
+	const lines = [];
+
+	if (res && res.stdout)
+		lines.push(res.stdout.trim());
+
+	if (res && res.stderr)
+		lines.push(res.stderr.trim());
+
+	return lines.filter(function(line) {
+		return line;
+	}).join('\n') || fallback || _('Command completed.');
+}
+
+function resultToError(result, fallback) {
+	return new Error(
+		_('%s failed with exit code %d: %s').format(
+			result.action || _('command'),
+			(result.code != null) ? result.code : -1,
+			result.message || fallback || _('Unknown error.')
+		)
+	);
+}
+
+function execService(action, extraArgs) {
+	return fs.exec('/etc/init.d/nordvpn-easy', [ action ].concat(extraArgs || []));
+}
+
+function runAction(action, extraArgs) {
+	return execService(action, extraArgs).then(function(res) {
+		return {
+			action: action,
+			code: res.code,
+			success: (res.code === 0),
+			stdout: res.stdout || '',
+			stderr: res.stderr || '',
+			message: responseMessage(res)
+		};
+	}).catch(function(err) {
+		return {
+			action: action,
+			code: -1,
+			success: false,
+			stdout: '',
+			stderr: '',
+			message: (err && err.message) ? err.message : String(err)
+		};
+	});
+}
+
+function runActions(actions) {
+	const results = [];
+
+	return actions.reduce(function(chain, action) {
+		return chain.then(function() {
+			return runAction(action).then(function(result) {
+				results.push(result);
+
+				if (!result.success) {
+					const error = resultToError(result);
+
+					error.result = result;
+					error.results = results.slice();
+					throw error;
+				}
+
+				return result;
+			});
+		});
+	}, Promise.resolve()).then(function() {
+		return results;
+	});
+}
+
+function parseExecJsonResponse(res, fallback) {
+	if (!res || res.code !== 0)
+		return fallback;
+
+	return parseJson(res.stdout || '', fallback);
+}
+
+function notifyInfo(message) {
+	ui.addNotification(null, E('p', message), 'info');
+}
+
+function notifyError(err, prefix) {
+	const message = (err && err.message) ? err.message : String(err);
+
+	ui.addNotification(null, E('p', prefix ? (prefix + message) : message), 'error');
+}
+
+function downloadTextFile(name, content) {
+	const blob = new Blob([ content ], { type: 'text/plain;charset=utf-8' });
+	const url = window.URL.createObjectURL(blob);
+	const link = E('a', {
+		style: 'display:none',
+		href: url,
+		download: name
+	});
+
+	document.body.appendChild(link);
+	link.click();
+	document.body.removeChild(link);
+	window.URL.revokeObjectURL(url);
+}
+
+return {
+	parseJson: parseJson,
+	parseExecJsonResponse: parseExecJsonResponse,
+	responseMessage: responseMessage,
+	resultToError: resultToError,
+	execService: execService,
+	runAction: runAction,
+	runActions: runActions,
+	notifyInfo: notifyInfo,
+	notifyError: notifyError,
+	downloadTextFile: downloadTextFile
+};

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/advanced.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/advanced.js
@@ -116,6 +116,23 @@ return view.extend({
 		o.datatype = 'uinteger';
 		o.rmempty = false;
 
+		s = m.section(form.NamedSection, 'main', 'nordvpn_easy', _('Cache'));
+		s.anonymous = true;
+		s.addremove = false;
+
+		o = s.option(form.Flag, 'server_cache_enabled', _('Enable Server Catalog Cache'));
+		o.default = '1';
+		o.rmempty = false;
+		o.description = _('Cache the NordVPN manual server catalog for the selected country.');
+
+		o = s.option(form.Value, 'server_cache_ttl', _('Server Catalog Cache TTL'));
+		o.datatype = 'uinteger';
+		o.default = '86400';
+		o.placeholder = '86400';
+		o.rmempty = false;
+		o.depends('server_cache_enabled', '1');
+		o.description = _('How long to keep the manual server catalog before refreshing it again.');
+
 		s = m.section(form.NamedSection, 'main', 'nordvpn_easy', _('Runtime'));
 		s.anonymous = true;
 		s.addremove = false;

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/advanced.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/advanced.js
@@ -1,32 +1,17 @@
 'use strict';
 'require form';
 'require fs';
-'require ui';
+'require nordvpn-easy/service as service';
 'require view';
 
 function runAction(action) {
-	return fs.exec('/etc/init.d/nordvpn-easy', [ action ]).then(function(res) {
-		const lines = [];
-
-		if (res.stdout)
-			lines.push(res.stdout.trim());
-
-		if (res.stderr)
-			lines.push(res.stderr.trim());
-
-		if (!lines.length)
-			lines.push(_('Command completed.'));
-
-		if (res.code !== 0) {
-			ui.addNotification(null, E('p', _(
-				'Command failed with exit code %d: %s'
-			).format(res.code, res.stderr ? res.stderr.trim() : lines.join('\n'))), 'error');
+	return service.runAction(action).then(function(result) {
+		if (!result.success) {
+			service.notifyError(service.resultToError(result));
 			return;
 		}
 
-		ui.addNotification(null, E('p', lines.join('\n')), 'info');
-	}).catch(function(err) {
-		ui.addNotification(null, E('p', _('Command failed: ') + err.message), 'error');
+		service.notifyInfo(result.message);
 	});
 }
 
@@ -46,7 +31,7 @@ return view.extend({
 		m = new form.Map('nordvpn_easy', _('NordVPN Easy Advanced'),
 			_('Adjust advanced network, health-check and recovery settings.'));
 
-		s = m.section(form.NamedSection, 'main', 'nordvpn_easy', _('Advanced Settings'));
+		s = m.section(form.NamedSection, 'main', 'nordvpn_easy', _('Network & Runtime'));
 		s.anonymous = true;
 		s.addremove = false;
 
@@ -75,6 +60,10 @@ return view.extend({
 		o = s.option(form.Value, 'vpn_dns2', _('DNS 2'));
 		o.placeholder = '103.86.96.96';
 		o.rmempty = true;
+
+		s = m.section(form.NamedSection, 'main', 'nordvpn_easy', _('Health Checks & Recovery'));
+		s.anonymous = true;
+		s.addremove = false;
 
 		o = s.option(form.Value, 'check_cron_schedule', _('Cron Schedule'));
 		o.placeholder = '* * * * *';
@@ -116,7 +105,7 @@ return view.extend({
 		o.datatype = 'uinteger';
 		o.rmempty = false;
 
-		s = m.section(form.NamedSection, 'main', 'nordvpn_easy', _('Cache'));
+		s = m.section(form.NamedSection, 'main', 'nordvpn_easy', _('Cache & Catalog'));
 		s.anonymous = true;
 		s.addremove = false;
 
@@ -133,7 +122,7 @@ return view.extend({
 		o.depends('server_cache_enabled', '1');
 		o.description = _('How long to keep the manual server catalog before refreshing it again.');
 
-		s = m.section(form.NamedSection, 'main', 'nordvpn_easy', _('Runtime'));
+		s = m.section(form.NamedSection, 'main', 'nordvpn_easy', _('Runtime Actions'));
 		s.anonymous = true;
 		s.addremove = false;
 

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -1,564 +1,24 @@
 'use strict';
 'require form';
 'require fs';
+'require nordvpn-easy/manager-data as managerData';
+'require nordvpn-easy/manager-format as managerFormat';
+'require nordvpn-easy/manager-state as managerState';
+'require nordvpn-easy/manager-ui as managerUI';
+'require nordvpn-easy/service as service';
 'require poll';
 'require ui';
 'require uci';
 'require view';
 
 const COUNTRIES_CACHE_PATH = '/tmp/nordvpn-easy-countries.json';
-const ENABLED_FIELD_ID = 'cbid.nordvpn_easy.main.enabled';
-const TOKEN_FIELD_ID = 'cbid.nordvpn_easy.main.nordvpn_token';
-const COUNTRY_FIELD_ID = 'cbid.nordvpn_easy.main.vpn_country';
-const COUNTRY_REFRESH_BUTTON_ID = 'cbid.nordvpn_easy.main.vpn_country.refresh';
-const MODE_FIELD_ID = 'cbid.nordvpn_easy.main.server_selection_mode';
-const SERVER_FIELD_ID = 'cbid.nordvpn_easy.main.preferred_server_station';
-const SERVER_CACHE_ENABLED_FIELD_ID = 'cbid.nordvpn_easy.main.server_cache_enabled';
-const SERVER_CACHE_TTL_FIELD_ID = 'cbid.nordvpn_easy.main.server_cache_ttl';
-const SERVER_REFRESH_BUTTON_ID = 'cbid.nordvpn_easy.main._refresh_servers';
-const VPN_STATUS_ID = 'nordvpn-easy-vpn-status';
-const CURRENT_SERVER_STATUS_ID = 'nordvpn-easy-current-server-status';
-const PREFERRED_SERVER_STATUS_ID = 'nordvpn-easy-preferred-server-status';
-const ENDPOINT_STATUS_ID = 'nordvpn-easy-endpoint-status';
-const HANDSHAKE_STATUS_ID = 'nordvpn-easy-handshake-status';
-const TRANSFER_STATUS_ID = 'nordvpn-easy-transfer-status';
-const OPERATION_STATUS_ID = 'nordvpn-easy-operation-status';
-const PUBLIC_IP_STATUS_ID = 'nordvpn-easy-public-ip-status';
-const PUBLIC_COUNTRY_STATUS_ID = 'nordvpn-easy-public-country-status';
-const COUNTRY_MATCH_STATUS_ID = 'nordvpn-easy-country-match-status';
-const SERVER_CATALOG_STATUS_ID = 'nordvpn-easy-server-catalog-status';
-const SERVER_SELECTION_HINT_ID = 'nordvpn-easy-server-selection-hint';
-
-let pendingOperationLabel = '';
-let currentOperationStatus = 'idle';
-let currentPublicCountry = '';
-let appliedEnabled = false;
-let appliedCountryCode = '';
-let currentLocalStatus = {};
-let currentServerCatalog = emptyServerCatalog();
-let serverCatalogIndex = {};
-let latestServerCatalogRequestId = 0;
-
-function emptyServerCatalog() {
-	return {
-		country_code: '',
-		country_name: '',
-		servers: []
-	};
-}
-
-function parseJson(raw, fallback) {
-	try {
-		return JSON.parse(raw || '');
-	} catch (e) {
-		return fallback;
-	}
-}
-
-function parseCountries(countriesRaw) {
-	const countries = parseJson(countriesRaw, []);
-
-	return countries.filter(function(country) {
-		return country && country.name && country.code;
-	}).sort(function(a, b) {
-		return String(a.name).localeCompare(String(b.name));
-	});
-}
-
-function parseLocalStatus(raw) {
-	const status = parseJson(raw, {});
-
-	return {
-		enabled: !!status.enabled,
-		server_selection_mode: String(status.server_selection_mode || 'auto'),
-		selected_country: normalizeCountryCode(status.selected_country || ''),
-		interface: String(status.interface || ''),
-		vpn_status: String(status.vpn_status || 'inactive'),
-		operation_status: String(status.operation_status || 'idle'),
-		connected: !!status.connected,
-		endpoint: String(status.endpoint || 'N/A'),
-		latest_handshake: String(status.latest_handshake || 'Never'),
-		transfer_rx: String(status.transfer_rx || '0 B'),
-		transfer_tx: String(status.transfer_tx || '0 B'),
-		current_server_hostname: String(status.current_server_hostname || ''),
-		current_server_station: String(status.current_server_station || ''),
-		current_server_city: String(status.current_server_city || ''),
-		current_server_country: normalizeCountryCode(status.current_server_country || ''),
-		current_server_load: String(status.current_server_load || ''),
-		preferred_server_hostname: String(status.preferred_server_hostname || ''),
-		preferred_server_station: String(status.preferred_server_station || '')
-	};
-}
-
-function parseServerCatalog(raw) {
-	const catalog = parseJson(raw, emptyServerCatalog());
-
-	if (!catalog || typeof catalog !== 'object')
-		return emptyServerCatalog();
-
-	return {
-		country_id: String(catalog.country_id || ''),
-		country_code: normalizeCountryCode(catalog.country_code || ''),
-		country_name: String(catalog.country_name || ''),
-		servers: Array.isArray(catalog.servers) ? catalog.servers.filter(function(server) {
-			return server && server.hostname && server.station && server.public_key;
-		}).map(function(server) {
-			return {
-				hostname: String(server.hostname),
-				station: String(server.station),
-				load: String(server.load != null ? server.load : ''),
-				city: String(server.city || ''),
-				country_code: normalizeCountryCode(server.country_code || ''),
-				country_name: String(server.country_name || ''),
-				public_key: String(server.public_key || '')
-			};
-		}) : []
-	};
-}
-
-function buildServerCatalogIndex(catalog) {
-	const index = {};
-
-	catalog.servers.forEach(function(server) {
-		index[String(server.station)] = server;
-	});
-
-	return index;
-}
-
-function humanizeAction(action) {
-	return String(action || _('operation')).replace(/_/g, ' ');
-}
-
-function formatActionsLabel(actions) {
-	return actions.map(humanizeAction).join(' + ');
-}
-
-function normalizeCountryCode(value) {
-	return String(value || '').trim().toUpperCase();
-}
-
-function getSelectElement(optionId) {
-	const frameEl = document.getElementById(optionId);
-
-	if (!frameEl)
-		return null;
-
-	if (frameEl.matches && frameEl.matches('select'))
-		return frameEl;
-
-	return frameEl.querySelector ? frameEl.querySelector('select') : null;
-}
-
-function getInputElement(optionId, selector) {
-	const fieldEl = document.getElementById(optionId);
-
-	if (!fieldEl)
-		return null;
-
-	if (!selector)
-		return fieldEl;
-
-	if (fieldEl.matches && fieldEl.matches(selector))
-		return fieldEl;
-
-	return fieldEl.querySelector ? fieldEl.querySelector(selector) : null;
-}
-
-function getEnabledCheckboxElement() {
-	return getInputElement(ENABLED_FIELD_ID, 'input[type="checkbox"]');
-}
-
-function getSelectedCountry() {
-	const selectEl = getSelectElement(COUNTRY_FIELD_ID);
-
-	return normalizeCountryCode(selectEl ? selectEl.value : '');
-}
-
-function getSelectedMode() {
-	const selectEl = getSelectElement(MODE_FIELD_ID);
-
-	return String(selectEl ? selectEl.value : 'auto');
-}
-
-function getSelectedPreferredStation() {
-	const selectEl = getSelectElement(SERVER_FIELD_ID);
-
-	return String(selectEl ? selectEl.value : '');
-}
-
-function renderCountryChoices(selectEl, countries, currentCountry) {
-	let seenCurrent = false;
-
-	if (!selectEl)
-		return;
-
-	while (selectEl.firstChild)
-		selectEl.removeChild(selectEl.firstChild);
-
-	selectEl.appendChild(E('option', { value: '' }, [ _('Automatic') ]));
-
-	countries.forEach(function(country) {
-		const value = String(country.code);
-
-		selectEl.appendChild(E('option', { value: value }, [
-			_('%s (%s)').format(country.name, value)
-		]));
-
-		if (value === currentCountry)
-			seenCurrent = true;
-	});
-
-	if (currentCountry && !seenCurrent) {
-		selectEl.appendChild(E('option', { value: currentCountry }, [
-			_('Current value: %s').format(currentCountry)
-		]));
-	}
-
-	selectEl.value = currentCountry || '';
-}
-
-function formatServerLabel(server) {
-	const parts = [];
-	let label;
-
-	if (server.country_name)
-		parts.push(server.country_name);
-	else if (server.country_code)
-		parts.push(server.country_code);
-
-	if (server.city)
-		parts.push(server.city);
-
-	if (server.hostname)
-		parts.push(server.hostname);
-
-	label = parts.join(' - ');
-
-	if (server.load !== '')
-		label += (label ? ' - ' : '') + _('Load %s%%').format(server.load);
-
-	return label || server.station;
-}
-
-function formatServerSummary(server) {
-	if (!server)
-		return _('Automatic / Best recommended');
-
-	return formatServerLabel(server);
-}
-
-function renderServerChoices(selectEl, catalog, currentStation) {
-	let seenCurrent = false;
-
-	if (!selectEl)
-		return;
-
-	while (selectEl.firstChild)
-		selectEl.removeChild(selectEl.firstChild);
-
-	selectEl.appendChild(E('option', { value: '' }, [
-		catalog.servers.length ? _('-- Select Server --') : _('No server catalog loaded')
-	]));
-
-	catalog.servers.forEach(function(server) {
-		const value = String(server.station);
-
-		selectEl.appendChild(E('option', { value: value }, [
-			formatServerLabel(server)
-		]));
-
-		if (value === currentStation)
-			seenCurrent = true;
-	});
-
-	if (currentStation && !seenCurrent) {
-		selectEl.appendChild(E('option', { value: currentStation }, [
-			_('Current value: %s').format(currentStation)
-		]));
-	}
-
-	selectEl.value = currentStation || '';
-}
-
-function setStatusIndicator(elementId, color, label) {
-	const statusEl = document.getElementById(elementId);
-
-	if (!statusEl)
-		return;
-
-	statusEl.replaceChildren(
-		E('span', {
-			style: 'display:inline-block;width:0.75rem;height:0.75rem;border-radius:50%;background:' + color + ';vertical-align:middle;margin-right:0.45rem;'
-		}),
-		document.createTextNode(label)
-	);
-}
-
-function setVpnStatusIndicator(state, label) {
-	let color = '#cf222e';
-
-	if (state === 'active')
-		color = '#2ea043';
-	else if (state === 'activating')
-		color = '#d29922';
-
-	setStatusIndicator(VPN_STATUS_ID, color, label);
-}
-
-function setCountryMatchIndicator(state, label) {
-	let color = '#cf222e';
-
-	switch (state) {
-	case 'match':
-		color = '#2ea043';
-		break;
-	case 'checking':
-	case 'automatic':
-		color = '#d29922';
-		break;
-	case 'inactive':
-	case 'unavailable':
-		color = '#8c959f';
-		break;
-	}
-
-	setStatusIndicator(COUNTRY_MATCH_STATUS_ID, color, label);
-}
-
-function replaceStatusText(elementId, value) {
-	const element = document.getElementById(elementId);
-
-	if (element)
-		element.textContent = value;
-}
-
-function currentServerSummaryFromStatus(status) {
-	if (!status || !status.current_server_station)
-		return _('Not configured');
-
-	return formatServerSummary({
-		hostname: status.current_server_hostname,
-		station: status.current_server_station,
-		city: status.current_server_city,
-		country_code: status.current_server_country,
-		load: status.current_server_load
-	});
-}
-
-function preferredServerSummaryFromStatus(status) {
-	if (!status)
-		return _('Automatic / Best recommended');
-
-	if (status.server_selection_mode !== 'manual')
-		return _('Automatic / Best recommended');
-
-	if (!status.preferred_server_station)
-		return _('Manual selection pending');
-
-	return formatServerSummary({
-		hostname: status.preferred_server_hostname,
-		station: status.preferred_server_station,
-		country_code: status.selected_country
-	});
-}
-
-function updateCountryMatchStatus() {
-	let busyAction;
-	const expectedCountry = normalizeCountryCode(appliedCountryCode);
-	const actualCountry = normalizeCountryCode(currentPublicCountry);
-
-	if (currentOperationStatus.indexOf('busy:') === 0) {
-		busyAction = currentOperationStatus.substring(5);
-
-		if (busyAction !== 'refresh_countries' && busyAction !== 'server_catalog')
-			return setCountryMatchIndicator('checking', _('Checking'));
-	}
-	else if (currentOperationStatus === 'busy') {
-		return setCountryMatchIndicator('checking', _('Checking'));
-	}
-
-	if (!appliedEnabled)
-		return setCountryMatchIndicator('inactive', _('Inactive'));
-
-	if (!expectedCountry)
-		return setCountryMatchIndicator('automatic', _('Automatic'));
-
-	if (!actualCountry)
-		return setCountryMatchIndicator('unavailable', _('Unavailable'));
-
-	if (actualCountry === expectedCountry)
-		return setCountryMatchIndicator('match', _('Match (%s)').format(actualCountry));
-
-	setCountryMatchIndicator('mismatch', _('Mismatch (%s)').format(actualCountry));
-}
-
-function setManagerControlsDisabled(disabled) {
-	[
-		ENABLED_FIELD_ID,
-		TOKEN_FIELD_ID,
-		COUNTRY_FIELD_ID,
-		COUNTRY_REFRESH_BUTTON_ID,
-		MODE_FIELD_ID,
-		SERVER_FIELD_ID,
-		SERVER_CACHE_ENABLED_FIELD_ID,
-		SERVER_CACHE_TTL_FIELD_ID,
-		SERVER_REFRESH_BUTTON_ID
-	].forEach(function(id) {
-		const fieldEl = document.getElementById(id);
-		const selectEl = getSelectElement(id);
-		const inputEl = getInputElement(id, 'input,button');
-
-		if (fieldEl && fieldEl.matches && fieldEl.matches('button'))
-			fieldEl.disabled = disabled;
-
-		if (selectEl)
-			selectEl.disabled = disabled;
-
-		if (inputEl)
-			inputEl.disabled = disabled;
-	});
-}
-
-function updateServerCatalogStatus() {
-	let text;
-	const mode = getSelectedMode();
-	const country = getSelectedCountry();
-	const selectionHintEl = document.getElementById(SERVER_SELECTION_HINT_ID);
-	const statusEl = document.getElementById(SERVER_CATALOG_STATUS_ID);
-
-	if (!country) {
-		text = _('Select a country to load the manual server catalog.');
-	}
-	else if (!currentServerCatalog.servers.length) {
-		text = _('No server catalog loaded for %s yet.').format(country);
-	}
-	else {
-		text = _('%d servers cached for %s').format(
-			currentServerCatalog.servers.length,
-			currentServerCatalog.country_name || currentServerCatalog.country_code || country
-		);
-	}
-
-	if (statusEl)
-		statusEl.textContent = text;
-
-	if (selectionHintEl) {
-		if (mode !== 'manual')
-			selectionHintEl.textContent = _('Automatic mode uses NordVPN recommended servers for the selected country.');
-		else if (!country)
-			selectionHintEl.textContent = _('Manual mode requires a country and a preferred server.');
-		else if (!currentServerCatalog.servers.length)
-			selectionHintEl.textContent = _('Use "Refresh Server List" to fetch the NordVPN catalog for the selected country.');
-		else
-			selectionHintEl.textContent = _('Manual mode is rigid during health checks. Rotate updates the saved preferred server.');
-	}
-}
-
-function updateServerSelectionState() {
-	const mode = getSelectedMode();
-	const country = getSelectedCountry();
-	const busy = currentOperationStatus.indexOf('busy') === 0;
-	const selectEl = getSelectElement(SERVER_FIELD_ID);
-	const actionButtons = [
-		{
-			element: getInputElement(SERVER_REFRESH_BUTTON_ID, 'button'),
-			disabled: busy || !country
-		}
-	];
-
-	updateServerCatalogStatus();
-
-	if (selectEl)
-		selectEl.disabled = busy || mode !== 'manual' || !country || !currentServerCatalog.servers.length;
-
-	actionButtons.forEach(function(button) {
-		if (button.element)
-			button.element.disabled = button.disabled;
-	});
-}
-
-function showConfirmationModal(title, lines) {
-	return new Promise(function(resolve) {
-		const body = [
-			E('p', {}, lines[0])
-		];
-
-		if (lines[1])
-			body.push(E('p', {}, lines[1]));
-
-		body.push(E('div', { class: 'right' }, [
-				E('button', {
-					class: 'btn',
-					click: function() {
-						ui.hideModal();
-						resolve(false);
-					}
-				}, [ _('Cancel') ]),
-				' ',
-				E('button', {
-					class: 'btn cbi-button-apply',
-					click: function() {
-						ui.hideModal();
-						resolve(true);
-					}
-				}, [ _('Apply') ])
-			])
-			);
-
-		ui.showModal(title, body);
-	});
-}
-
-function parseExecJsonResponse(res, fallback) {
-	if (!res || res.code !== 0)
-		return fallback;
-
-	return parseJson(res.stdout || '', fallback);
-}
-
-function loadServerCatalog(country, forceRefresh) {
-	const requestId = ++latestServerCatalogRequestId;
-	const requestedCountry = normalizeCountryCode(country || '');
-	const args = [ 'server_catalog', country || '' ];
-
-	if (!country) {
-		currentServerCatalog = emptyServerCatalog();
-		serverCatalogIndex = {};
-		renderServerChoices(getSelectElement(SERVER_FIELD_ID), currentServerCatalog, '');
-		updateServerSelectionState();
-		return Promise.resolve(currentServerCatalog);
-	}
-
-	if (forceRefresh)
-		args.push('1');
-
-	return fs.exec('/etc/init.d/nordvpn-easy', args).then(function(res) {
-		let message;
-		let parsedCatalog;
-
-		if (requestId !== latestServerCatalogRequestId || requestedCountry !== getSelectedCountry())
-			return null;
-
-		if (res.code !== 0) {
-			message = (res.stderr || '').trim() || _('Server catalog refresh failed.');
-			throw new Error(message);
-		}
-
-		parsedCatalog = parseServerCatalog(res.stdout || '');
-		currentServerCatalog = parsedCatalog;
-		serverCatalogIndex = buildServerCatalogIndex(parsedCatalog);
-		renderServerChoices(getSelectElement(SERVER_FIELD_ID), parsedCatalog, getSelectedPreferredStation());
-		updateServerSelectionState();
-		return currentServerCatalog;
-	});
-}
+const state = managerState.createState();
 
 const CountrySelectValue = form.ListValue.extend({
 	refreshCountries: function(buttonEl, section_id) {
 		buttonEl.disabled = true;
 
-		return fs.exec('/etc/init.d/nordvpn-easy', [ 'refresh_countries_force' ]).then(function(res) {
+		return service.execService('refresh_countries_force').then(function(res) {
 			let message;
 
 			if (res.code !== 0) {
@@ -568,14 +28,14 @@ const CountrySelectValue = form.ListValue.extend({
 
 			return fs.read(COUNTRIES_CACHE_PATH);
 		}.bind(this)).then(function(countriesRaw) {
-			const selectEl = getSelectElement(this.cbid(section_id));
-			const currentCountry = selectEl ? normalizeCountryCode(selectEl.value) : '';
-			const countries = parseCountries(countriesRaw);
+			const selectEl = managerUI.getSelectElement(this.cbid(section_id));
+			const currentCountry = selectEl ? managerData.normalizeCountryCode(selectEl.value) : '';
+			const countries = managerData.parseCountries(countriesRaw);
 
-			renderCountryChoices(selectEl, countries, currentCountry);
-			ui.addNotification(null, E('p', _('Country list refreshed.')), 'info');
+			managerUI.renderCountryChoices(selectEl, countries, currentCountry);
+			service.notifyInfo(_('Country list refreshed.'));
 		}.bind(this)).catch(function(err) {
-			ui.addNotification(null, E('p', err.message), 'error');
+			service.notifyError(err);
 		}).finally(function() {
 			buttonEl.disabled = false;
 		});
@@ -600,7 +60,7 @@ const CountrySelectValue = form.ListValue.extend({
 		}, [
 			E('div', { style: 'display:inline-block;width:18rem;max-width:100%;' }, [ widget.render() ]),
 			E('button', {
-				id: COUNTRY_REFRESH_BUTTON_ID,
+				id: managerUI.ids.COUNTRY_REFRESH_BUTTON_ID,
 				class: 'cbi-button cbi-button-action',
 				type: 'button',
 				click: ui.createHandlerFn(this, function(section_id, ev) {
@@ -613,252 +73,17 @@ const CountrySelectValue = form.ListValue.extend({
 	}
 });
 
-function runServiceAction(action) {
-	return fs.exec('/etc/init.d/nordvpn-easy', [ action ]).then(function(res) {
-		const lines = [];
-
-		if (res.stdout)
-			lines.push(res.stdout.trim());
-
-		if (res.stderr)
-			lines.push(res.stderr.trim());
-
-		return {
-			action: action,
-			code: res.code,
-			message: lines.filter(function(line) {
-				return line;
-			}).join('\n') || _('Command completed.')
-		};
-	}).catch(function(err) {
-		return {
-			action: action,
-			code: -1,
-			message: (err && err.message) ? err.message : String(err)
-		};
-	});
-}
-
-function runServiceActions(actions) {
-	const results = [];
-
-	return actions.reduce(function(chain, action) {
-		return chain.then(function() {
-			return runServiceAction(action).then(function(result) {
-				results.push(result);
-
-				if (result.code !== 0) {
-					const error = new Error(
-						_('%s failed with exit code %d: %s').format(result.action, result.code, result.message)
-					);
-
-					error.result = result;
-					error.results = results.slice();
-					throw error;
-				}
-
-				return result;
-			});
-		});
-	}, Promise.resolve()).then(function() {
-		return results;
-	});
-}
-
-function summarizeActionFailures(results) {
-	return results.filter(function(result) {
-		return result.code !== 0;
-	}).map(function(result) {
-		return _('%s failed with exit code %d: %s').format(result.action, result.code, result.message);
-	}).join('\n');
-}
-
-function updatePublicIp() {
-	return fs.exec('/etc/init.d/nordvpn-easy', [ 'public_ip' ]).then(function(res) {
-		const publicIp = res.stdout ? res.stdout.trim() : '';
-
-		replaceStatusText(PUBLIC_IP_STATUS_ID,
-			(res.code === 0 && publicIp && publicIp !== 'null' && publicIp !== 'undefined') ? publicIp : _('Unavailable'));
-	}).catch(function() {
-		replaceStatusText(PUBLIC_IP_STATUS_ID, _('Unavailable'));
-	});
-}
-
-function updatePublicCountry() {
-	return fs.exec('/etc/init.d/nordvpn-easy', [ 'public_country' ]).then(function(res) {
-		const publicCountry = normalizeCountryCode(res.stdout ? res.stdout.trim() : '');
-
-		currentPublicCountry = (res.code === 0 && publicCountry) ? publicCountry : '';
-		replaceStatusText(PUBLIC_COUNTRY_STATUS_ID, currentPublicCountry || _('Unavailable'));
-		updateCountryMatchStatus();
-	}).catch(function() {
-		currentPublicCountry = '';
-		replaceStatusText(PUBLIC_COUNTRY_STATUS_ID, _('Unavailable'));
-		updateCountryMatchStatus();
-	});
-}
-
-function updateLocalStatus() {
-	return fs.exec('/etc/init.d/nordvpn-easy', [ 'status_json' ]).then(function(res) {
-		let busyAction;
-
-		currentLocalStatus = parseExecJsonResponse(res, parseLocalStatus('{}'));
-		currentOperationStatus = String(currentLocalStatus.operation_status || 'idle');
-		appliedEnabled = !!currentLocalStatus.enabled;
-		appliedCountryCode = normalizeCountryCode(currentLocalStatus.selected_country || appliedCountryCode);
-
-		replaceStatusText(CURRENT_SERVER_STATUS_ID, currentServerSummaryFromStatus(currentLocalStatus));
-		replaceStatusText(PREFERRED_SERVER_STATUS_ID, preferredServerSummaryFromStatus(currentLocalStatus));
-		replaceStatusText(ENDPOINT_STATUS_ID, currentLocalStatus.endpoint || _('Unavailable'));
-		replaceStatusText(HANDSHAKE_STATUS_ID, currentLocalStatus.latest_handshake || _('Never'));
-		replaceStatusText(TRANSFER_STATUS_ID,
-			_('%s / %s').format(currentLocalStatus.transfer_rx || '0 B', currentLocalStatus.transfer_tx || '0 B'));
-
-		if (currentOperationStatus.indexOf('busy:') === 0) {
-			busyAction = currentOperationStatus.substring(5);
-			replaceStatusText(OPERATION_STATUS_ID, _('Applying (%s)...').format(humanizeAction(busyAction)));
-			setManagerControlsDisabled(true);
-
-			if (busyAction !== 'refresh_countries' && busyAction !== 'server_catalog') {
-				setVpnStatusIndicator('activating', _('Activating'));
-				updateCountryMatchStatus();
-				updateServerSelectionState();
-				return;
-			}
-		}
-		else if (currentOperationStatus === 'busy') {
-			replaceStatusText(OPERATION_STATUS_ID, _('Applying...'));
-			setVpnStatusIndicator('activating', _('Activating'));
-			setManagerControlsDisabled(true);
-			updateCountryMatchStatus();
-			updateServerSelectionState();
-			return;
-		}
-
-		if (pendingOperationLabel) {
-			replaceStatusText(OPERATION_STATUS_ID, _('Applying (%s)...').format(humanizeAction(pendingOperationLabel)));
-			setVpnStatusIndicator('activating', _('Activating'));
-			setManagerControlsDisabled(true);
-		}
-		else if (currentOperationStatus !== 'busy' && currentOperationStatus.indexOf('busy:') !== 0) {
-			replaceStatusText(OPERATION_STATUS_ID, _('Idle'));
-			setManagerControlsDisabled(false);
-		}
-
-		if (currentLocalStatus.connected || currentLocalStatus.vpn_status === 'active')
-			setVpnStatusIndicator('active', _('Connected'));
-		else
-			setVpnStatusIndicator('inactive', _('Disconnected'));
-
-		updateCountryMatchStatus();
-		updateServerSelectionState();
-	}).catch(function() {
-		currentOperationStatus = pendingOperationLabel ? ('busy:' + pendingOperationLabel) : 'unknown';
-		replaceStatusText(OPERATION_STATUS_ID, pendingOperationLabel ? _('Applying (%s)...').format(humanizeAction(pendingOperationLabel)) : _('Unknown'));
-		setVpnStatusIndicator(pendingOperationLabel ? 'activating' : 'inactive',
-			pendingOperationLabel ? _('Activating') : _('Disconnected'));
-		if (!pendingOperationLabel)
-			setManagerControlsDisabled(false);
-		updateCountryMatchStatus();
-		updateServerSelectionState();
-	});
-}
-
-function onCountryChanged() {
-	const country = getSelectedCountry();
-	const selectEl = getSelectElement(SERVER_FIELD_ID);
-
-	if (selectEl)
-		selectEl.value = '';
-
-	if (!country) {
-		latestServerCatalogRequestId++;
-		currentServerCatalog = emptyServerCatalog();
-		serverCatalogIndex = {};
-		renderServerChoices(selectEl, currentServerCatalog, '');
-		updateServerSelectionState();
-		return Promise.resolve();
-	}
-
-	currentServerCatalog = emptyServerCatalog();
-	serverCatalogIndex = {};
-	renderServerChoices(selectEl, currentServerCatalog, '');
-	updateServerSelectionState();
-
-	return loadServerCatalog(country, false).catch(function(err) {
-		ui.addNotification(null, E('p', err.message), 'error');
-	});
-}
-
-function onModeChanged() {
-	if (getSelectedMode() !== 'manual') {
-		const selectEl = getSelectElement(SERVER_FIELD_ID);
-
-		if (selectEl)
-			selectEl.value = '';
-	}
-
-	updateServerSelectionState();
-}
-
-function renderStatusSection() {
-	return E('div', { class: 'table-wrapper' }, [
-		E('table', { class: 'table' }, [
-			E('tr', { class: 'tr' }, [
-				E('td', { class: 'td left', style: 'width: 30%; font-weight: bold' }, [ _('Connection') ]),
-				E('td', { class: 'td left' }, [ E('span', { id: VPN_STATUS_ID }, [ _('Collecting data...') ]) ])
-			]),
-			E('tr', { class: 'tr' }, [
-				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Current Server') ]),
-				E('td', { class: 'td left', id: CURRENT_SERVER_STATUS_ID }, [ _('Collecting data...') ])
-			]),
-			E('tr', { class: 'tr' }, [
-				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Preferred Server') ]),
-				E('td', { class: 'td left', id: PREFERRED_SERVER_STATUS_ID }, [ _('Collecting data...') ])
-			]),
-			E('tr', { class: 'tr' }, [
-				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Endpoint') ]),
-				E('td', { class: 'td left', id: ENDPOINT_STATUS_ID }, [ _('Collecting data...') ])
-			]),
-			E('tr', { class: 'tr' }, [
-				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Latest Handshake') ]),
-				E('td', { class: 'td left', id: HANDSHAKE_STATUS_ID }, [ _('Collecting data...') ])
-			]),
-			E('tr', { class: 'tr' }, [
-				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Transfer (RX / TX)') ]),
-				E('td', { class: 'td left', id: TRANSFER_STATUS_ID }, [ _('Collecting data...') ])
-			]),
-			E('tr', { class: 'tr' }, [
-				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Operation Status') ]),
-				E('td', { class: 'td left', id: OPERATION_STATUS_ID }, [ _('Collecting data...') ])
-			]),
-			E('tr', { class: 'tr' }, [
-				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Public IP') ]),
-				E('td', { class: 'td left', id: PUBLIC_IP_STATUS_ID }, [ _('Collecting data...') ])
-			]),
-			E('tr', { class: 'tr' }, [
-				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Public Country') ]),
-				E('td', { class: 'td left', id: PUBLIC_COUNTRY_STATUS_ID }, [ _('Collecting data...') ])
-			]),
-			E('tr', { class: 'tr' }, [
-				E('td', { class: 'td left', style: 'font-weight: bold' }, [ _('Country Match') ]),
-				E('td', { class: 'td left' }, [ E('span', { id: COUNTRY_MATCH_STATUS_ID }, [ _('Checking') ]) ])
-			])
-		])
-	]);
-}
-
 return view.extend({
 	load: function() {
 		return Promise.all([
-			L.resolveDefault(fs.exec('/etc/init.d/nordvpn-easy', [ 'refresh_countries' ]), null),
+			L.resolveDefault(service.execService('refresh_countries'), null),
 			L.resolveDefault(fs.read(COUNTRIES_CACHE_PATH), '[]'),
 			uci.load('nordvpn_easy')
 		]).then(function(results) {
-			const configuredCountry = normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
-			const statusPromise = L.resolveDefault(fs.exec('/etc/init.d/nordvpn-easy', [ 'status_json' ]), null);
+			const configuredCountry = managerData.normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
+			const statusPromise = L.resolveDefault(service.execService('status_json'), null);
 			const catalogPromise = configuredCountry
-				? L.resolveDefault(fs.exec('/etc/init.d/nordvpn-easy', [ 'server_catalog', configuredCountry ]), null)
+				? L.resolveDefault(service.execService('server_catalog', [ configuredCountry ]), null)
 				: Promise.resolve(null);
 
 			return Promise.all([ Promise.resolve(results[1]), statusPromise, catalogPromise ]);
@@ -866,39 +91,14 @@ return view.extend({
 	},
 
 	handleRefreshServerCatalog: function(ev) {
-		const country = getSelectedCountry();
-		const button = ev ? ev.currentTarget : getInputElement(SERVER_REFRESH_BUTTON_ID, 'button');
-
-		if (!country) {
-			ui.addNotification(null, E('p', _('Select a country before refreshing the server catalog.')), 'warning');
-			return Promise.resolve();
-		}
-
-		if (button)
-			button.disabled = true;
-
-		ui.showModal(_('Refreshing Server List'), [
-			E('p', { class: 'spinning' }, _('Downloading the NordVPN WireGuard server catalog...'))
-		]);
-
-		return loadServerCatalog(country, true).then(function(catalog) {
-			if (catalog)
-				ui.addNotification(null, E('p', _('Server catalog refreshed.')), 'info');
-		}).catch(function(err) {
-			ui.addNotification(null, E('p', err.message), 'error');
-		}).finally(function() {
-			ui.hideModal();
-			if (button)
-				button.disabled = false;
-			updateServerSelectionState();
-		});
+		return managerState.handleRefreshServerCatalog(state, ev);
 	},
 
 	render: function(data) {
-		const countries = parseCountries(data[0]);
-		const initialStatus = parseExecJsonResponse(data[1], parseLocalStatus('{}'));
-		const initialCatalog = data[2] ? parseExecJsonResponse(data[2], emptyServerCatalog()) : emptyServerCatalog();
-		const currentCountry = normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
+		const countries = managerData.parseCountries(data[0]);
+		const initialStatus = managerData.parseLocalStatus(data[1] && data[1].code === 0 ? data[1].stdout || '{}' : '{}');
+		const initialCatalog = managerData.parseServerCatalog(data[2] && data[2].code === 0 ? data[2].stdout || '{}' : '{}');
+		const currentCountry = managerData.normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
 		const currentMode = String(uci.get('nordvpn_easy', 'main', 'server_selection_mode') || 'auto');
 		const currentPreferredStation = String(uci.get('nordvpn_easy', 'main', 'preferred_server_station') || '');
 		let m, s, o;
@@ -908,12 +108,12 @@ return view.extend({
 		this.initialMode = currentMode;
 		this.initialPreferredStation = currentPreferredStation;
 
-		appliedEnabled = this.initialEnabled;
-		appliedCountryCode = currentCountry;
-		currentLocalStatus = initialStatus;
-		currentOperationStatus = String(initialStatus.operation_status || 'idle');
-		currentServerCatalog = parseServerCatalog(JSON.stringify(initialCatalog));
-		serverCatalogIndex = buildServerCatalogIndex(currentServerCatalog);
+		state.appliedEnabled = this.initialEnabled;
+		state.appliedCountryCode = currentCountry;
+		state.currentLocalStatus = initialStatus;
+		state.currentOperationStatus = String(initialStatus.operation_status || 'idle');
+		state.currentServerCatalog = initialCatalog;
+		state.serverCatalogIndex = managerData.buildServerCatalogIndex(state.currentServerCatalog);
 
 		m = new form.Map('nordvpn_easy', _('NordVPN Easy'),
 			_('Manage NordVPN Easy connection, manual server selection and runtime status.'));
@@ -923,7 +123,7 @@ return view.extend({
 		s.addremove = false;
 		s.render = function() {
 			return E('div', { class: 'cbi-section' }, [
-				E('div', { class: 'cbi-section-node' }, [ renderStatusSection() ])
+				E('div', { class: 'cbi-section-node' }, [ managerUI.renderStatusSection() ])
 			]);
 		};
 
@@ -963,7 +163,7 @@ return view.extend({
 		o = s.option(form.DummyValue, '_server_catalog_status', _('Catalog Status'));
 		o.rawhtml = true;
 		o.cfgvalue = function() {
-			return '<span id="%s">%s</span>'.format(SERVER_CATALOG_STATUS_ID, _('Collecting data...'));
+			return '<span id="%s">%s</span>'.format(managerUI.ids.SERVER_CATALOG_STATUS_ID, _('Collecting data...'));
 		};
 
 		o = s.option(form.ListValue, 'preferred_server_station', _('Preferred Server'));
@@ -972,14 +172,14 @@ return view.extend({
 		o.rmempty = true;
 		o.depends('server_selection_mode', 'manual');
 		o.description = _('Label format: Country - City - Hostname - Load%.');
-		currentServerCatalog.servers.forEach(function(server) {
-			o.value(String(server.station), formatServerLabel(server));
+		state.currentServerCatalog.servers.forEach(function(server) {
+			o.value(String(server.station), managerFormat.formatServerLabel(server));
 		});
 
 		o = s.option(form.DummyValue, '_server_selection_hint', _('Selection Behaviour'));
 		o.rawhtml = true;
 		o.cfgvalue = function() {
-			return '<span id="%s">%s</span>'.format(SERVER_SELECTION_HINT_ID, _('Collecting data...'));
+			return '<span id="%s">%s</span>'.format(managerUI.ids.SERVER_SELECTION_HINT_ID, _('Collecting data...'));
 		};
 
 		o = s.option(form.Button, '_refresh_servers', _('Refresh Server List'));
@@ -990,37 +190,37 @@ return view.extend({
 		o.inputtitle = _('Refresh Server List');
 
 		return m.render().then(function(node) {
-			const countrySelect = getSelectElement(COUNTRY_FIELD_ID);
-			const modeSelect = getSelectElement(MODE_FIELD_ID);
+			const countrySelect = managerUI.getSelectElement(managerUI.ids.COUNTRY_FIELD_ID);
+			const modeSelect = managerUI.getSelectElement(managerUI.ids.MODE_FIELD_ID);
 
-			renderServerChoices(getSelectElement(SERVER_FIELD_ID), currentServerCatalog, currentPreferredStation);
-			updateLocalStatus();
-			updatePublicIp();
-			updatePublicCountry();
-			updateServerSelectionState();
+			managerUI.renderServerChoices(managerUI.getSelectElement(managerUI.ids.SERVER_FIELD_ID), state.currentServerCatalog, currentPreferredStation);
+			managerState.updateLocalStatus(state);
+			managerState.updatePublicIp();
+			managerState.updatePublicCountry(state);
+			managerUI.updateServerSelectionState(state);
 
 			if (countrySelect) {
 				countrySelect.addEventListener('change', function() {
-					onCountryChanged();
+					managerState.onCountryChanged(state);
 				});
 			}
 
 			if (modeSelect) {
 				modeSelect.addEventListener('change', function() {
-					onModeChanged();
+					managerState.onModeChanged(state);
 				});
 			}
 
 			poll.add(function() {
-				return updateLocalStatus();
+				return managerState.updateLocalStatus(state);
 			}, 2);
 
 			poll.add(function() {
-				return updatePublicIp();
+				return managerState.updatePublicIp();
 			}, 10);
 
 			poll.add(function() {
-				return updatePublicCountry();
+				return managerState.updatePublicCountry(state);
 			}, 30);
 
 			return node;
@@ -1028,195 +228,6 @@ return view.extend({
 	},
 
 	handleSaveApply: function(ev, mode) {
-		const previousEnabled = !!this.initialEnabled;
-		const previousCountry = this.initialCountry || '';
-		const previousMode = this.initialMode || 'auto';
-		const previousPreferredStation = this.initialPreferredStation || '';
-		const currentMode = getSelectedMode();
-		const currentCountry = getSelectedCountry();
-		const preferredStation = getSelectedPreferredStation();
-		const preferredStationChanged = (currentMode === 'manual' && preferredStation !== previousPreferredStation);
-		const enteringManualMode = (currentMode === 'manual' && previousMode !== 'manual');
-		const selectedServer = preferredStation ? serverCatalogIndex[preferredStation] : null;
-		const preservingExistingManualPreference = (
-			currentMode === 'manual' &&
-			previousMode === 'manual' &&
-			!preferredStationChanged &&
-			preferredStation === previousPreferredStation &&
-			!!preferredStation
-		);
-		let confirmationPromise = Promise.resolve(true);
-
-		if (currentMode === 'manual') {
-			if (!currentCountry) {
-				ui.addNotification(null, E('p', _('Manual mode requires a selected country.')), 'error');
-				return Promise.resolve();
-			}
-
-			if ((!preferredStation || !selectedServer) && !preservingExistingManualPreference) {
-				ui.addNotification(null, E('p', _('Manual mode requires a valid preferred server from the current catalog.')), 'error');
-				return Promise.resolve();
-			}
-
-			if (preferredStationChanged || enteringManualMode) {
-				uci.set('nordvpn_easy', 'main', 'preferred_server_hostname', selectedServer.hostname);
-				uci.set('nordvpn_easy', 'main', 'preferred_server_station', preferredStation);
-			}
-		}
-		else {
-			uci.set('nordvpn_easy', 'main', 'preferred_server_hostname', '');
-			uci.set('nordvpn_easy', 'main', 'preferred_server_station', '');
-		}
-
-		if (previousEnabled && getEnabledCheckboxElement() && !getEnabledCheckboxElement().checked) {
-			confirmationPromise = showConfirmationModal(
-				_('Disable NordVPN Easy'),
-				[
-					_('Disabling NordVPN Easy will stop the VPN interface and remove cron/hotplug hooks.'),
-					_('Your current VPN connection will be interrupted.')
-				]
-			);
-		}
-		else if (previousEnabled && (
-			previousCountry !== currentCountry ||
-			previousMode !== currentMode ||
-			(currentMode === 'manual' && previousPreferredStation !== preferredStation)
-		)) {
-			confirmationPromise = showConfirmationModal(
-				_('Confirm Server Change'),
-				[
-					_('Applying these changes will briefly interrupt the VPN connection while NordVPN Easy reconfigures the tunnel.'),
-					currentMode === 'manual'
-						? (selectedServer
-							? _('Preferred server: %s').format(formatServerLabel(selectedServer))
-							: (preferredStation
-								? _('Preferred server unchanged: %s').format(preferredStation)
-								: _('Manual mode will keep the existing preferred server settings.')))
-						: _('Automatic mode will use NordVPN recommended servers.')
-				]
-			);
-		}
-
-		return confirmationPromise.then(function(confirmed) {
-			if (!confirmed)
-				return;
-
-			return this.handleSave(ev).then(function() {
-				return new Promise(function(resolve, reject) {
-					let settled = false;
-
-					const cleanup = function() {
-						if (this._uciAppliedHandler) {
-							document.removeEventListener('uci-applied', this._uciAppliedHandler);
-							this._uciAppliedHandler = null;
-						}
-					}.bind(this);
-
-					const finishResolve = function(value) {
-						if (settled)
-							return;
-
-						settled = true;
-						cleanup();
-						resolve(value);
-					};
-
-					const finishReject = function(err) {
-						if (settled)
-							return;
-
-						settled = true;
-						cleanup();
-						reject(err);
-					};
-
-					cleanup();
-
-					this._uciAppliedHandler = function() {
-						Promise.resolve().then(function() {
-							uci.unload('nordvpn_easy');
-							return uci.load('nordvpn_easy');
-						}).then(function() {
-							const enabled = (uci.get('nordvpn_easy', 'main', 'enabled') !== '0');
-							const country = normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
-							const modeValue = String(uci.get('nordvpn_easy', 'main', 'server_selection_mode') || 'auto');
-							const preferred = String(uci.get('nordvpn_easy', 'main', 'preferred_server_station') || '');
-							let actions = [];
-							let successMessage = '';
-
-							this.initialEnabled = enabled;
-							this.initialCountry = country;
-							this.initialMode = modeValue;
-							this.initialPreferredStation = preferred;
-							appliedEnabled = enabled;
-							appliedCountryCode = country;
-
-							if (!previousEnabled && enabled) {
-								actions = [ 'setup', 'install_hooks' ];
-								successMessage = _('NordVPN Easy enabled: setup completed and hooks installed.');
-							}
-							else if (previousEnabled && !enabled) {
-								actions = [ 'disable_runtime' ];
-								successMessage = _('NordVPN Easy disabled: VPN interface stopped and hooks removed.');
-							}
-							else if (enabled && (
-								previousCountry !== country ||
-								previousMode !== modeValue ||
-								(modeValue === 'manual' && previousPreferredStation !== preferred)
-							)) {
-								actions = [ 'setup' ];
-								successMessage = modeValue === 'manual'
-									? _('Manual preferred server updated and synchronized.')
-									: _('NordVPN Easy synchronized the automatic server selection.');
-							}
-
-							if (!actions.length) {
-								pendingOperationLabel = '';
-								updateLocalStatus();
-								finishResolve();
-								return;
-							}
-
-							pendingOperationLabel = formatActionsLabel(actions);
-							currentOperationStatus = 'busy:' + pendingOperationLabel;
-							updateLocalStatus();
-
-							runServiceActions(actions).then(function(results) {
-								const failures = summarizeActionFailures(results);
-
-								if (failures) {
-									ui.addNotification(null, E('p', failures), 'error');
-									finishReject(new Error(failures));
-									return;
-								}
-
-								ui.addNotification(null, E('p', successMessage), 'info');
-								finishResolve();
-							}).catch(function(err) {
-								finishReject(err);
-							}).finally(function() {
-								pendingOperationLabel = '';
-								updateLocalStatus();
-								updatePublicIp();
-								updatePublicCountry();
-							});
-						}.bind(this)).catch(function(err) {
-							const message = (err && err.message) ? err.message : String(err);
-
-							ui.addNotification(null, E('p', _('Automatic runtime sync failed: ') + message), 'error');
-							finishReject(err);
-						});
-					}.bind(this);
-
-					document.addEventListener('uci-applied', this._uciAppliedHandler);
-					pendingOperationLabel = _('configuration');
-					currentOperationStatus = 'busy:configuration';
-					updateLocalStatus();
-					Promise.resolve(ui.changes.apply(mode === '0')).catch(function(err) {
-						finishReject(err);
-					});
-				}.bind(this));
-			}.bind(this));
-		}.bind(this));
+		return managerState.handleSaveApply(this, state, ev, mode);
 	}
 });

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -75,11 +75,16 @@ const CountrySelectValue = form.ListValue.extend({
 
 return view.extend({
 	load: function() {
-		return Promise.all([
-			L.resolveDefault(service.execService('refresh_countries'), null),
-			L.resolveDefault(fs.read(COUNTRIES_CACHE_PATH), '[]'),
-			uci.load('nordvpn_easy')
-		]).then(function(results) {
+		const uciLoad = uci.load('nordvpn_easy');
+
+		return L.resolveDefault(service.execService('refresh_countries'), null).then(function() {
+			return L.resolveDefault(fs.read(COUNTRIES_CACHE_PATH), '[]');
+		}).then(function(countriesRaw) {
+			return Promise.all([
+				Promise.resolve(countriesRaw),
+				uciLoad
+			]);
+		}).then(function(results) {
 			const configuredCountry = managerData.normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
 			const statusPromise = L.resolveDefault(service.execService('status_json'), null);
 			const catalogPromise = configuredCountry

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -91,7 +91,7 @@ return view.extend({
 				? L.resolveDefault(service.execService('server_catalog', [ configuredCountry ]), null)
 				: Promise.resolve(null);
 
-			return Promise.all([ Promise.resolve(results[1]), statusPromise, catalogPromise ]);
+			return Promise.all([ Promise.resolve(results[0]), statusPromise, catalogPromise ]);
 		});
 	},
 

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -15,10 +15,7 @@ const MODE_FIELD_ID = 'cbid.nordvpn_easy.main.server_selection_mode';
 const SERVER_FIELD_ID = 'cbid.nordvpn_easy.main.preferred_server_station';
 const SERVER_CACHE_ENABLED_FIELD_ID = 'cbid.nordvpn_easy.main.server_cache_enabled';
 const SERVER_CACHE_TTL_FIELD_ID = 'cbid.nordvpn_easy.main.server_cache_ttl';
-const ACTION_BAR_ID = 'nordvpn-easy-manager-actions';
 const SERVER_REFRESH_BUTTON_ID = 'cbid.nordvpn_easy.main._refresh_servers';
-const SERVER_REFRESH_BUTTON_ID_TOP = 'nordvpn-easy-refresh-servers-top';
-const SAVE_APPLY_BUTTON_ID = 'nordvpn-easy-save-apply-top';
 const VPN_STATUS_ID = 'nordvpn-easy-vpn-status';
 const CURRENT_SERVER_STATUS_ID = 'nordvpn-easy-current-server-status';
 const PREFERRED_SERVER_STATUS_ID = 'nordvpn-easy-preferred-server-status';
@@ -406,9 +403,7 @@ function setManagerControlsDisabled(disabled) {
 		SERVER_FIELD_ID,
 		SERVER_CACHE_ENABLED_FIELD_ID,
 		SERVER_CACHE_TTL_FIELD_ID,
-		SERVER_REFRESH_BUTTON_ID,
-		SERVER_REFRESH_BUTTON_ID_TOP,
-		SAVE_APPLY_BUTTON_ID
+		SERVER_REFRESH_BUTTON_ID
 	].forEach(function(id) {
 		const fieldEl = document.getElementById(id);
 		const selectEl = getSelectElement(id);
@@ -469,14 +464,6 @@ function updateServerSelectionState() {
 		{
 			element: getInputElement(SERVER_REFRESH_BUTTON_ID, 'button'),
 			disabled: busy || !country
-		},
-		{
-			element: document.getElementById(SERVER_REFRESH_BUTTON_ID_TOP),
-			disabled: busy || !country
-		},
-		{
-			element: document.getElementById(SAVE_APPLY_BUTTON_ID),
-			disabled: busy
 		}
 	];
 
@@ -861,26 +848,6 @@ function renderStatusSection() {
 	]);
 }
 
-function renderActionBar(viewInstance) {
-	return E('div', { id: ACTION_BAR_ID, class: 'cbi-page-actions' }, [
-		E('button', {
-			id: SERVER_REFRESH_BUTTON_ID_TOP,
-			class: 'btn cbi-button cbi-button-action',
-			type: 'button',
-			click: ui.createHandlerFn(viewInstance, 'handleRefreshServerCatalog')
-		}, [ _('Refresh Server List') ]),
-		' ',
-		E('button', {
-			id: SAVE_APPLY_BUTTON_ID,
-			class: 'btn cbi-button cbi-button-apply',
-			type: 'button',
-			click: ui.createHandlerFn(viewInstance, function(ev) {
-				return this.handleSaveApply(ev, '0');
-			})
-		}, [ _('Save & Apply') ])
-	]);
-}
-
 return view.extend({
 	load: function() {
 		return Promise.all([
@@ -900,7 +867,7 @@ return view.extend({
 
 	handleRefreshServerCatalog: function(ev) {
 		const country = getSelectedCountry();
-		const button = ev ? ev.currentTarget : document.getElementById(SERVER_REFRESH_BUTTON_ID_TOP);
+		const button = ev ? ev.currentTarget : getInputElement(SERVER_REFRESH_BUTTON_ID, 'button');
 
 		if (!country) {
 			ui.addNotification(null, E('p', _('Select a country before refreshing the server catalog.')), 'warning');
@@ -1022,27 +989,9 @@ return view.extend({
 		});
 		o.inputtitle = _('Refresh Server List');
 
-		s = m.section(form.NamedSection, 'main', 'nordvpn_easy', _('Cache'));
-		s.anonymous = true;
-		s.addremove = false;
-
-		o = s.option(form.Flag, 'server_cache_enabled', _('Enable Server Catalog Cache'));
-		o.default = '1';
-		o.rmempty = false;
-		o.description = _('Cache the NordVPN manual server catalog for the selected country.');
-
-		o = s.option(form.Value, 'server_cache_ttl', _('Server Catalog Cache TTL'));
-		o.datatype = 'uinteger';
-		o.placeholder = '86400';
-		o.rmempty = false;
-		o.depends('server_cache_enabled', '1');
-		o.description = _('How long to keep the manual server catalog before refreshing it again.');
-
 		return m.render().then(function(node) {
 			const countrySelect = getSelectElement(COUNTRY_FIELD_ID);
 			const modeSelect = getSelectElement(MODE_FIELD_ID);
-
-			node.appendChild(renderActionBar(this));
 
 			renderServerChoices(getSelectElement(SERVER_FIELD_ID), currentServerCatalog, currentPreferredStation);
 			updateLocalStatus();

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/diagnostics.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/diagnostics.js
@@ -1,31 +1,7 @@
 'use strict';
-'require fs';
+'require nordvpn-easy/service as service';
 'require ui';
 'require view';
-
-function downloadLogFile(content) {
-	const now = new Date();
-	const name = 'nordvpn-easy-diagnostics-%04d-%02d-%02d_%02d-%02d-%02d.log'.format(
-		now.getFullYear(),
-		now.getMonth() + 1,
-		now.getDate(),
-		now.getHours(),
-		now.getMinutes(),
-		now.getSeconds()
-	);
-	const blob = new Blob([ content ], { type: 'text/plain;charset=utf-8' });
-	const url = window.URL.createObjectURL(blob);
-	const link = E('a', {
-		'style': 'display:none',
-		'href': url,
-		'download': name
-	});
-
-	document.body.appendChild(link);
-	link.click();
-	document.body.removeChild(link);
-	window.URL.revokeObjectURL(url);
-}
 
 return view.extend({
 	handleSaveApply: null,
@@ -47,32 +23,41 @@ return view.extend({
 							'type': 'button',
 							'click': ui.createHandlerFn(this, function(ev) {
 								const button = ev.currentTarget;
+								const now = new Date();
+								const fileName = 'nordvpn-easy-diagnostics-%04d-%02d-%02d_%02d-%02d-%02d.log'.format(
+									now.getFullYear(),
+									now.getMonth() + 1,
+									now.getDate(),
+									now.getHours(),
+									now.getMinutes(),
+									now.getSeconds()
+								);
 
 								button.disabled = true;
 
-								return fs.exec('/etc/init.d/nordvpn-easy', [ 'diagnostics_log' ]).then(function(res) {
+								return service.execService('diagnostics_log').then(function(res) {
 									const content = res.stdout || '';
 									const message = res.stderr ? res.stderr.trim() : '';
 
 									if (res.code !== 0) {
-										ui.addNotification(null, E('p', _(
+										service.notifyError(new Error(_(
 											'Log export failed with exit code %d: %s'
-										).format(res.code, message || _('Unknown error.'))), 'error');
+										).format(res.code, message || _('Unknown error.'))));
 										return;
 									}
 
 									if (!content.trim()) {
-										ui.addNotification(null, E('p', _('No NordVPN Easy logs are currently available.')), 'info');
+										service.notifyInfo(_('No NordVPN Easy logs are currently available.'));
 										return;
 									}
 
-									downloadLogFile(content);
+									service.downloadTextFile(fileName, content);
 								}).catch(function(err) {
 									const message = (err && err.message) ||
 										(typeof err === 'string' ? err : JSON.stringify(err)) ||
 										_('Unknown error');
 
-									ui.addNotification(null, E('p', _('Log export failed: ') + message), 'error');
+									service.notifyError(new Error(_('Log export failed: ') + message));
 								}).finally(function() {
 									button.disabled = false;
 								});

--- a/openwrt-packages/nordvpn-easy/Makefile
+++ b/openwrt-packages/nordvpn-easy/Makefile
@@ -40,6 +40,8 @@ endef
 define Package/nordvpn-easy/install
 	$(INSTALL_DIR) $(1)/usr/libexec/nordvpn-easy
 	$(INSTALL_BIN) ./files/usr/libexec/nordvpn-easy/core.sh $(1)/usr/libexec/nordvpn-easy/core.sh
+	$(INSTALL_DIR) $(1)/usr/libexec/nordvpn-easy/lib
+	$(CP) ./files/usr/libexec/nordvpn-easy/lib/. $(1)/usr/libexec/nordvpn-easy/lib/
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/etc/config/nordvpn_easy $(1)/etc/config/nordvpn_easy
 	$(INSTALL_DIR) $(1)/etc/init.d

--- a/openwrt-packages/nordvpn-easy/files/etc/config/nordvpn_easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/config/nordvpn_easy
@@ -1,6 +1,7 @@
 config nordvpn_easy 'main'
 	option enabled '0'
 	option nordvpn_token ''
+	option config_schema_version '2'
 	option wan_if 'wan'
 	option vpn_if 'wg0'
 	option vpn_country ''

--- a/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
@@ -10,6 +10,9 @@ UCI_CONFIG='nordvpn_easy'
 UCI_SECTION='main'
 RUNTIME_CONFIG='/var/etc/nordvpn-easy.conf'
 CORE_SCRIPT='/usr/libexec/nordvpn-easy/core.sh'
+SCHEMA_LIB='/usr/libexec/nordvpn-easy/lib/schema.sh'
+RUNTIME_LIB='/usr/libexec/nordvpn-easy/lib/runtime.sh'
+SERVICE_CONFIG_LIB='/usr/libexec/nordvpn-easy/lib/service-config.sh'
 CRON_PATH='/etc/cron.d/nordvpn-easy'
 HOTPLUG_PATH='/etc/hotplug.d/iface/95-nordvpn-easy'
 LOCK_DIR='/tmp/nordvpn-easy.lock'
@@ -31,102 +34,92 @@ EXTRA_HELP='  setup                 Run setup immediately
   disable_runtime       Disable the VPN interface and remove hooks
   render_runtime_config Render the temporary shell config'
 
-cfg_enabled='0'
-cfg_nordvpn_token=''
-cfg_wan_if='wan'
-cfg_vpn_if='wg0'
-cfg_vpn_country=''
-cfg_server_selection_mode='auto'
-cfg_preferred_server_hostname=''
-cfg_preferred_server_station=''
-cfg_server_cache_enabled='1'
-cfg_server_cache_ttl='86400'
-cfg_vpn_port='51820'
-cfg_vpn_addr='10.5.0.2/32'
-cfg_vpn_dns1='103.86.99.99'
-cfg_vpn_dns2='103.86.96.96'
-cfg_check_cron_schedule='* * * * *'
-cfg_enable_hotplug='1'
-cfg_failure_retry_delay='6'
-cfg_server_rotate_threshold='5'
-cfg_interface_restart_threshold='10'
-cfg_max_interface_restarts='3'
-cfg_interface_restart_delay='10'
-cfg_post_restart_delay='60'
+SCHEMA_LIB_LOADED=0
+RUNTIME_LIB_LOADED=0
+SERVICE_CONFIG_LIB_LOADED=0
 
-cleanup_legacy_config() {
-	if uci -q get "${UCI_CONFIG}.${UCI_SECTION}.nordvpn_basic_token" >/dev/null 2>&1; then
-		uci -q delete "${UCI_CONFIG}.${UCI_SECTION}.nordvpn_basic_token"
-		uci -q commit "$UCI_CONFIG"
-	fi
+load_schema_library() {
+	[ "$SCHEMA_LIB_LOADED" -eq 1 ] && return 0
+	[ -r "$SCHEMA_LIB" ] || {
+		printf '%s\n' "nordvpn-easy: missing schema library $SCHEMA_LIB" >&2
+		return 1
+	}
+
+	# shellcheck disable=SC1090
+	. "$SCHEMA_LIB" || return 1
+	SCHEMA_LIB_LOADED=1
+}
+
+load_runtime_library() {
+	[ "$RUNTIME_LIB_LOADED" -eq 1 ] && return 0
+	[ -r "$RUNTIME_LIB" ] || {
+		printf '%s\n' "nordvpn-easy: missing runtime library $RUNTIME_LIB" >&2
+		return 1
+	}
+
+	# shellcheck disable=SC1090
+	. "$RUNTIME_LIB" || return 1
+	RUNTIME_LIB_LOADED=1
+}
+
+load_service_config_library() {
+	[ "$SERVICE_CONFIG_LIB_LOADED" -eq 1 ] && return 0
+	[ -r "$SERVICE_CONFIG_LIB" ] || {
+		printf '%s\n' "nordvpn-easy: missing service config library $SERVICE_CONFIG_LIB" >&2
+		return 1
+	}
+
+	load_schema_library || return 1
+	# shellcheck disable=SC1090
+	. "$SERVICE_CONFIG_LIB" || return 1
+	SERVICE_CONFIG_LIB_LOADED=1
+}
+
+migrate_service_config() {
+	load_service_config_library || return 1
+	nordvpn_easy_migrate_service_config "$UCI_CONFIG" "$UCI_SECTION"
 }
 
 load_service_config() {
-	cleanup_legacy_config
-	config_load "$UCI_CONFIG"
-	config_get_bool cfg_enabled "$UCI_SECTION" enabled 0
-	config_get cfg_nordvpn_token "$UCI_SECTION" nordvpn_token ''
-	config_get cfg_wan_if "$UCI_SECTION" wan_if 'wan'
-	config_get cfg_vpn_if "$UCI_SECTION" vpn_if 'wg0'
-	config_get cfg_vpn_country "$UCI_SECTION" vpn_country ''
-	config_get cfg_server_selection_mode "$UCI_SECTION" server_selection_mode 'auto'
-	config_get cfg_preferred_server_hostname "$UCI_SECTION" preferred_server_hostname ''
-	config_get cfg_preferred_server_station "$UCI_SECTION" preferred_server_station ''
-	config_get cfg_server_cache_enabled "$UCI_SECTION" server_cache_enabled '1'
-	config_get cfg_server_cache_ttl "$UCI_SECTION" server_cache_ttl '86400'
-	config_get cfg_vpn_port "$UCI_SECTION" vpn_port '51820'
-	config_get cfg_vpn_addr "$UCI_SECTION" vpn_addr '10.5.0.2/32'
-	config_get cfg_vpn_dns1 "$UCI_SECTION" vpn_dns1 '103.86.99.99'
-	config_get cfg_vpn_dns2 "$UCI_SECTION" vpn_dns2 '103.86.96.96'
-	config_get cfg_check_cron_schedule "$UCI_SECTION" check_cron_schedule '* * * * *'
-	config_get_bool cfg_enable_hotplug "$UCI_SECTION" enable_hotplug 1
-	config_get cfg_failure_retry_delay "$UCI_SECTION" failure_retry_delay '6'
-	config_get cfg_server_rotate_threshold "$UCI_SECTION" server_rotate_threshold '5'
-	config_get cfg_interface_restart_threshold "$UCI_SECTION" interface_restart_threshold '10'
-	config_get cfg_max_interface_restarts "$UCI_SECTION" max_interface_restarts '3'
-	config_get cfg_interface_restart_delay "$UCI_SECTION" interface_restart_delay '10'
-	config_get cfg_post_restart_delay "$UCI_SECTION" post_restart_delay '60'
-}
+	local option default_value
 
-shell_quote() {
-	printf "%s" "$1" | sed "s/'/'\\\\''/g"
+	load_schema_library || return 1
+	migrate_service_config || return 1
+	config_load "$UCI_CONFIG"
+
+	for option in $(nordvpn_easy_uci_options); do
+		[ "$option" = 'config_schema_version' ] && continue
+		default_value="$(nordvpn_easy_default "$option" 2>/dev/null || printf '%s' '')"
+
+		if nordvpn_easy_is_bool_option "$option"; then
+			config_get_bool "cfg_${option}" "$UCI_SECTION" "$option" "$default_value"
+		else
+			config_get "cfg_${option}" "$UCI_SECTION" "$option" "$default_value"
+		fi
+	done
 }
 
 write_runtime_option() {
 	local key="$1"
 	local value="$2"
 
-	printf "%s='%s'\n" "$key" "$(shell_quote "$value")" >> "$RUNTIME_CONFIG"
+	printf "%s='%s'\n" "$key" "$(nordvpn_easy_shell_quote "$value")" >> "$RUNTIME_CONFIG"
 }
 
 render_runtime_config() {
+	local option env_name value
+
 	load_service_config
 	umask 077
 	mkdir -p /var/etc
 	: > "$RUNTIME_CONFIG" || return 1
 	log_service_info "rendering runtime config to $RUNTIME_CONFIG (enabled=$cfg_enabled, wan_if=$cfg_wan_if, vpn_if=$cfg_vpn_if, vpn_country=${cfg_vpn_country:-automatic})"
 
-	write_runtime_option NORDVPN_TOKEN "$cfg_nordvpn_token"
-	write_runtime_option WAN_IF "$cfg_wan_if"
-	write_runtime_option VPN_IF "$cfg_vpn_if"
-	write_runtime_option VPN_COUNTRY "$cfg_vpn_country"
-	write_runtime_option SERVER_SELECTION_MODE "$cfg_server_selection_mode"
-	write_runtime_option PREFERRED_SERVER_HOSTNAME "$cfg_preferred_server_hostname"
-	write_runtime_option PREFERRED_SERVER_STATION "$cfg_preferred_server_station"
-	write_runtime_option SERVER_CACHE_ENABLED "$cfg_server_cache_enabled"
-	write_runtime_option SERVER_CACHE_TTL "$cfg_server_cache_ttl"
-	write_runtime_option VPN_PORT "$cfg_vpn_port"
-	write_runtime_option VPN_ADDR "$cfg_vpn_addr"
-	write_runtime_option VPN_DNS1 "$cfg_vpn_dns1"
-	write_runtime_option VPN_DNS2 "$cfg_vpn_dns2"
-	write_runtime_option CHECK_CRON_SCHEDULE "$cfg_check_cron_schedule"
-	write_runtime_option ENABLE_HOTPLUG "$cfg_enable_hotplug"
-	write_runtime_option FAILURE_RETRY_DELAY "$cfg_failure_retry_delay"
-	write_runtime_option SERVER_ROTATE_THRESHOLD "$cfg_server_rotate_threshold"
-	write_runtime_option INTERFACE_RESTART_THRESHOLD "$cfg_interface_restart_threshold"
-	write_runtime_option MAX_INTERFACE_RESTARTS "$cfg_max_interface_restarts"
-	write_runtime_option INTERFACE_RESTART_DELAY "$cfg_interface_restart_delay"
-	write_runtime_option POST_RESTART_DELAY "$cfg_post_restart_delay"
+	for option in $(nordvpn_easy_runtime_options); do
+		env_name="$(nordvpn_easy_env_name "$option")"
+		eval "value=\${cfg_${option}}"
+		write_runtime_option "$env_name" "$value"
+	done
 }
 
 run_core_action() {
@@ -244,23 +237,6 @@ peer_section_name() {
 	uci show network 2>/dev/null | grep "^network\..*=wireguard_${cfg_vpn_if}$" | head -1 | cut -d. -f2 | cut -d= -f1
 }
 
-handshake_indicates_connection() {
-	local handshake="$1"
-	local hours
-
-	case "$handshake" in
-		''|Never)
-			return 1
-			;;
-		*second*|*minute*)
-			return 0
-			;;
-	esac
-
-	hours="$(printf '%s' "$handshake" | sed -n 's/^\([0-9][0-9]*\) hour.*/\1/p')"
-	[ -n "$hours" ] && [ "$hours" -le 2 ]
-}
-
 validate_cron_schedule() {
 	local schedule="$1"
 
@@ -316,8 +292,8 @@ install_hotplug_hook() {
 
 	cat > "$HOTPLUG_PATH" <<EOF
 #!/bin/sh
-WAN_IF='$(shell_quote "$cfg_wan_if")'
-VPN_IF='$(shell_quote "$cfg_vpn_if")'
+WAN_IF='$(nordvpn_easy_shell_quote "$cfg_wan_if")'
+VPN_IF='$(nordvpn_easy_shell_quote "$cfg_vpn_if")'
 
 case "\$ACTION" in
 	ifup|ifupdate|ifdown) ;;
@@ -460,13 +436,16 @@ vpn_status() {
 
 status_json() {
 	local peer_section
-	local wg_status
+	local wg_dump
 	local vpn_state
 	local operation
 	local endpoint='N/A'
 	local latest_handshake='Never'
+	local latest_handshake_epoch='0'
 	local transfer_rx='0 B'
+	local transfer_rx_bytes='0'
 	local transfer_tx='0 B'
+	local transfer_tx_bytes='0'
 	local connected='false'
 	local current_hostname=''
 	local current_station=''
@@ -477,6 +456,7 @@ status_json() {
 	local preferred_station=''
 
 	load_service_config
+	load_runtime_library || return 1
 	peer_section="$(peer_section_name)"
 	vpn_state="$(vpn_status_value)"
 	operation="$(get_operation_status_value)"
@@ -495,20 +475,18 @@ status_json() {
 	preferred_hostname="$cfg_preferred_server_hostname"
 	preferred_station="$cfg_preferred_server_station"
 
-	wg_status="$(wg show "$cfg_vpn_if" 2>/dev/null)"
+	wg_dump="$(wg show "$cfg_vpn_if" dump 2>/dev/null)"
 
-	if [ -n "$wg_status" ]; then
-		endpoint="$(printf '%s\n' "$wg_status" | grep 'endpoint:' | awk '{print $2}' | head -1)"
-		latest_handshake="$(printf '%s\n' "$wg_status" | grep 'latest handshake:' | sed 's/.*latest handshake: //' | head -1)"
-		transfer_rx="$(printf '%s\n' "$wg_status" | grep 'transfer:' | awk '{print $2, $3}' | head -1)"
-		transfer_tx="$(printf '%s\n' "$wg_status" | grep 'transfer:' | awk '{print $5, $6}' | head -1)"
+	if [ -n "$wg_dump" ]; then
+		IFS="$(printf '\t')" read -r endpoint latest_handshake_epoch transfer_rx_bytes transfer_tx_bytes <<EOF
+$(nordvpn_easy_parse_wg_dump_peer "$wg_dump")
+EOF
 
-		[ -n "$endpoint" ] || endpoint='N/A'
-		[ -n "$latest_handshake" ] || latest_handshake='Never'
-		[ -n "$transfer_rx" ] || transfer_rx='0 B'
-		[ -n "$transfer_tx" ] || transfer_tx='0 B'
+		latest_handshake="$(nordvpn_easy_humanize_handshake_age "$latest_handshake_epoch")"
+		transfer_rx="$(nordvpn_easy_format_human_bytes "$transfer_rx_bytes")"
+		transfer_tx="$(nordvpn_easy_format_human_bytes "$transfer_tx_bytes")"
 
-		if handshake_indicates_connection "$latest_handshake"; then
+		if nordvpn_easy_handshake_epoch_indicates_connection "$latest_handshake_epoch"; then
 			connected='true'
 		fi
 	fi
@@ -524,8 +502,11 @@ status_json() {
   "connected": $connected,
   "endpoint": "$(json_escape "$endpoint")",
   "latest_handshake": "$(json_escape "$latest_handshake")",
+  "latest_handshake_epoch": $latest_handshake_epoch,
   "transfer_rx": "$(json_escape "$transfer_rx")",
+  "transfer_rx_bytes": $transfer_rx_bytes,
   "transfer_tx": "$(json_escape "$transfer_tx")",
+  "transfer_tx_bytes": $transfer_tx_bytes,
   "current_server_hostname": "$(json_escape "$current_hostname")",
   "current_server_station": "$(json_escape "$current_station")",
   "current_server_city": "$(json_escape "$current_city")",

--- a/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
@@ -109,7 +109,7 @@ write_runtime_option() {
 render_runtime_config() {
 	local option env_name value
 
-	load_service_config
+	load_service_config || return 1
 	umask 077
 	mkdir -p /var/etc
 	: > "$RUNTIME_CONFIG" || return 1

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -538,6 +538,7 @@ fetch_server_catalog () {
   COUNTRY_QUERY="${2:-$VPN_COUNTRY}"
   SERVER_CATALOG_TMP="${SERVER_CATALOG_FILE}.tmp.$$"
   SERVER_CATALOG_TS_TMP="${SERVER_CATALOG_TS_FILE}.tmp.$$"
+  SERVER_CATALOG_RAW_TMP="${SERVER_CATALOG_TMP}.raw"
   SERVER_CATALOG_URL=''
 
   [ -n "$COUNTRY_QUERY" ] || {
@@ -555,38 +556,53 @@ fetch_server_catalog () {
   SERVER_CATALOG_URL="${SERVER_CATALOG_URL_BASE}&filters[country_id]=$RESOLVED_COUNTRY_ID"
   log "Refreshing NordVPN server catalog for $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
 
-  curl -g -fsS --connect-timeout 15 --max-time 45 "$SERVER_CATALOG_URL" | \
-    nordvpn_easy_build_server_catalog_json "$RESOLVED_COUNTRY_ID" "$RESOLVED_COUNTRY_CODE" "$RESOLVED_COUNTRY_NAME" \
-    > "$SERVER_CATALOG_TMP" 2>/dev/null || {
-      rm -f "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
+  curl -g -fsS --connect-timeout 15 --max-time 45 -o "$SERVER_CATALOG_RAW_TMP" "$SERVER_CATALOG_URL" || {
+      rm -f "$SERVER_CATALOG_RAW_TMP" "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
       server_catalog_cache_matches_country "$RESOLVED_COUNTRY_ID" && return 0
-      log "ERROR: COULD NOT REFRESH SERVER CATALOG FOR $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
+      log "ERROR: COULD NOT DOWNLOAD SERVER CATALOG FOR $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
       return 1
     }
 
+  [ -s "$SERVER_CATALOG_RAW_TMP" ] || {
+    rm -f "$SERVER_CATALOG_RAW_TMP" "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
+    server_catalog_cache_matches_country "$RESOLVED_COUNTRY_ID" && return 0
+    log "ERROR: EMPTY SERVER CATALOG RESPONSE FOR $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
+    return 1
+  }
+
+  nordvpn_easy_build_server_catalog_json "$RESOLVED_COUNTRY_ID" "$RESOLVED_COUNTRY_CODE" "$RESOLVED_COUNTRY_NAME" \
+    < "$SERVER_CATALOG_RAW_TMP" > "$SERVER_CATALOG_TMP" 2>/dev/null || {
+      rm -f "$SERVER_CATALOG_RAW_TMP" "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
+      server_catalog_cache_matches_country "$RESOLVED_COUNTRY_ID" && return 0
+      log "ERROR: COULD NOT TRANSFORM SERVER CATALOG FOR $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
+      return 1
+    }
+
+  rm -f "$SERVER_CATALOG_RAW_TMP"
+
   nordvpn_easy_server_catalog_has_servers "$SERVER_CATALOG_TMP" || {
-    rm -f "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
+    rm -f "$SERVER_CATALOG_RAW_TMP" "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
     server_catalog_cache_matches_country "$RESOLVED_COUNTRY_ID" && return 0
     log "ERROR: NO WIREGUARD SERVERS FOUND FOR COUNTRY '$COUNTRY_QUERY'"
     return 1
   }
 
   date +%s > "$SERVER_CATALOG_TS_TMP" || {
-    rm -f "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
+    rm -f "$SERVER_CATALOG_RAW_TMP" "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
     server_catalog_cache_matches_country "$RESOLVED_COUNTRY_ID" && return 0
     log 'ERROR: COULD NOT WRITE SERVER CATALOG TIMESTAMP'
     return 1
   }
 
   mv "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_FILE" || {
-    rm -f "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
+    rm -f "$SERVER_CATALOG_RAW_TMP" "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
     server_catalog_cache_matches_country "$RESOLVED_COUNTRY_ID" && return 0
     log 'ERROR: COULD NOT UPDATE SERVER CATALOG CACHE'
     return 1
   }
 
   mv "$SERVER_CATALOG_TS_TMP" "$SERVER_CATALOG_TS_FILE" || {
-    rm -f "$SERVER_CATALOG_TS_TMP"
+    rm -f "$SERVER_CATALOG_RAW_TMP" "$SERVER_CATALOG_TS_TMP"
     server_catalog_cache_matches_country "$RESOLVED_COUNTRY_ID" && return 0
     log 'ERROR: COULD NOT UPDATE SERVER CATALOG TIMESTAMP'
     return 1

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -305,7 +305,7 @@ valid_country_code () {
 }
 
 get_public_ip () {
-  local curl_out curl_rc valid_ip_check
+  local curl_out curl_rc
 
   log "get_public_ip: starting IPv4-only public IP lookup (system DNS: $(grep '^nameserver' /etc/resolv.conf 2>/dev/null | awk '{print $2}' | tr '\n' ' ' | sed 's/ $//'))"
 
@@ -396,8 +396,12 @@ lookup_public_country_by_ip () {
 
   log "lookup_public_country_by_ip: raw response for $LOOKUP_IP: $curl_raw"
 
-  country_raw=$(printf '%s' "$curl_raw" | jq -er '.country // empty' 2>/dev/null)
-  if [ $? -ne 0 ] || [ -z "$country_raw" ]; then
+  if ! country_raw=$(printf '%s' "$curl_raw" | jq -er '.country // empty' 2>/dev/null); then
+    log "ERROR: COULD NOT PARSE COUNTRY FROM RESPONSE FOR $LOOKUP_IP (raw='$curl_raw')"
+    return 1
+  fi
+
+  if [ -z "$country_raw" ]; then
     log "ERROR: COULD NOT PARSE COUNTRY FROM RESPONSE FOR $LOOKUP_IP (raw='$curl_raw')"
     return 1
   fi

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -2,27 +2,26 @@
 
 # Use NORDVPN_TOKEN with the token you get from https://my.nordaccount.com/dashboard/nordvpn/access-tokens/
 
-NORDVPN_TOKEN="${NORDVPN_TOKEN:-}"
-WAN_IF="${WAN_IF:-wan}"
-VPN_IF="${VPN_IF:-wg0}"
-VPN_COUNTRY="${VPN_COUNTRY:-}"                 # optional: country code (IT), country name (Italy) or country id
-SERVER_SELECTION_MODE="${SERVER_SELECTION_MODE:-auto}"
-PREFERRED_SERVER_HOSTNAME="${PREFERRED_SERVER_HOSTNAME:-}"
-PREFERRED_SERVER_STATION="${PREFERRED_SERVER_STATION:-}"
-SERVER_CACHE_ENABLED="${SERVER_CACHE_ENABLED:-1}"
-SERVER_CACHE_TTL="${SERVER_CACHE_TTL:-86400}"
-VPN_PORT="${VPN_PORT:-51820}"                 # NordVPN-recommended default; can be changed via LuCI or env
-VPN_ADDR="${VPN_ADDR:-10.5.0.2/32}"           # NordVPN-recommended default; can be changed via LuCI or env
-VPN_DNS1="${VPN_DNS1:-103.86.99.99}"          # optional: these are the Threat Protection Lite DNS servers
-VPN_DNS2="${VPN_DNS2:-103.86.96.96}"          # optional: these are the Threat Protection Lite DNS servers
-CHECK_CRON_SCHEDULE="${CHECK_CRON_SCHEDULE:-* * * * *}"
-ENABLE_HOTPLUG="${ENABLE_HOTPLUG:-1}"
-FAILURE_RETRY_DELAY="${FAILURE_RETRY_DELAY:-6}"
-SERVER_ROTATE_THRESHOLD="${SERVER_ROTATE_THRESHOLD:-5}"
-INTERFACE_RESTART_THRESHOLD="${INTERFACE_RESTART_THRESHOLD:-10}"
-MAX_INTERFACE_RESTARTS="${MAX_INTERFACE_RESTARTS:-3}"
-INTERFACE_RESTART_DELAY="${INTERFACE_RESTART_DELAY:-10}"
-POST_RESTART_DELAY="${POST_RESTART_DELAY:-60}"
+LIB_DIR='/usr/libexec/nordvpn-easy/lib'
+SCHEMA_LIB="${LIB_DIR}/schema.sh"
+COMMON_LIB="${LIB_DIR}/common.sh"
+CATALOG_LIB="${LIB_DIR}/catalog.sh"
+WIREGUARD_LIB="${LIB_DIR}/wireguard.sh"
+ACTIONS_LIB="${LIB_DIR}/actions.sh"
+
+# shellcheck disable=SC1090
+. "$SCHEMA_LIB" || exit 1
+# shellcheck disable=SC1090
+. "$COMMON_LIB" || exit 1
+# shellcheck disable=SC1090
+. "$CATALOG_LIB" || exit 1
+# shellcheck disable=SC1090
+. "$WIREGUARD_LIB" || exit 1
+# shellcheck disable=SC1090
+. "$ACTIONS_LIB" || exit 1
+
+nordvpn_easy_apply_env_defaults
+
 VPN_INTERFACE_PRESENT_DELAY="${VPN_INTERFACE_PRESENT_DELAY:-10}"
 
 SERVER_LIST_FILE='/tmp/nordvpn.json'
@@ -73,21 +72,11 @@ IP18='209.244.0.3'
 IP19='209.244.0.4'
 
 log () {
-  [ -t 2 ] && printf '*** %s ***\n' "$*" >&2
-  command -v logger >/dev/null 2>&1 && logger -t 'nordvpn-easy' "$*"
+  nordvpn_easy_log "$@"
 }
 
 curl_rc_meaning () {
-  case "$1" in
-    0)  printf 'ok' ;;
-    6)  printf 'could not resolve host (DNS failure)' ;;
-    7)  printf 'failed to connect to host' ;;
-    28) printf 'operation timed out' ;;
-    35) printf 'SSL/TLS handshake failed' ;;
-    52) printf 'empty reply from server' ;;
-    56) printf 'receive failure' ;;
-    *)  printf 'curl error %s' "$1" ;;
-  esac
+  nordvpn_easy_curl_rc_meaning "$@"
 }
 
 usage () {
@@ -112,14 +101,7 @@ EOF
 }
 
 lock_contention_is_nonfatal () {
-  case "$ACTION" in
-    run|check|refresh_countries)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  nordvpn_easy_lock_contention_is_nonfatal "$@"
 }
 
 load_config () {
@@ -136,213 +118,63 @@ load_config () {
 }
 
 require_commands () {
-  log 'Validating required system commands'
-  for cmd in awk curl ifdown ifup ip jq ping uci; do
-    command -v "$cmd" >/dev/null 2>&1 || {
-      log "$cmd IS MISSING, PLEASE INSTALL"
-      return 1
-    }
-  done
-  log 'Required system commands are available'
+  nordvpn_easy_require_commands "$@"
 }
 
 server_selection_is_manual () {
-  [ "$SERVER_SELECTION_MODE" = 'manual' ]
+  nordvpn_easy_server_selection_is_manual "$@"
 }
 
 server_cache_is_enabled () {
-  [ "$SERVER_CACHE_ENABLED" = '1' ]
+  nordvpn_easy_server_cache_is_enabled "$@"
 }
 
 current_server_station () {
-  uci -q get "network.${VPN_IF}server.nordvpn_station" 2>/dev/null || \
-  uci -q get "network.${VPN_IF}server.endpoint_host" 2>/dev/null
+  nordvpn_easy_current_server_station "$@"
 }
 
 set_server_preference_in_uci () {
-  uci set "nordvpn_easy.main.preferred_server_hostname"="$1"
-  uci set "nordvpn_easy.main.preferred_server_station"="$2"
+  nordvpn_easy_set_server_preference_in_uci "$@"
 }
 
 require_manual_server_preference () {
-  server_selection_is_manual || return 0
-
-  [ -n "$VPN_COUNTRY" ] || {
-    log 'ERROR: MANUAL SERVER SELECTION REQUIRES A VPN_COUNTRY'
-    return 1
-  }
-
-  [ -n "$PREFERRED_SERVER_HOSTNAME" ] || {
-    log 'ERROR: MANUAL SERVER SELECTION REQUIRES A PREFERRED_SERVER_HOSTNAME'
-    return 1
-  }
-
-  [ -n "$PREFERRED_SERVER_STATION" ] || {
-    log 'ERROR: MANUAL SERVER SELECTION REQUIRES A PREFERRED_SERVER_STATION'
-    return 1
-  }
+  nordvpn_easy_require_manual_server_preference "$@"
 }
 
 server_cache_ttl_value () {
-  case "$SERVER_CACHE_TTL" in
-    ''|*[!0-9]*)
-      printf '%s\n' '86400'
-      ;;
-    *)
-      printf '%s\n' "$SERVER_CACHE_TTL"
-      ;;
-  esac
+  nordvpn_easy_server_cache_ttl_value "$@"
 }
 
 release_lock () {
-  [ "$LOCK_ACQUIRED" -eq 1 ] || return 0
-  rm -rf "$LOCK_DIR"
-  LOCK_ACQUIRED=0
-  log "Released execution lock at $LOCK_DIR"
+  nordvpn_easy_release_lock "$@"
 }
 
 acquire_lock () {
-  LOCK_PID_FILE="$LOCK_DIR/pid"
-  LOCK_ACTION_FILE="$LOCK_DIR/action"
-
-  if mkdir "$LOCK_DIR" 2>/dev/null; then
-    printf '%s\n' "$$" > "$LOCK_PID_FILE"
-    printf '%s\n' "$ACTION" > "$LOCK_ACTION_FILE"
-    LOCK_ACQUIRED=1
-    trap 'release_lock' EXIT HUP INT TERM
-    log "Acquired execution lock at $LOCK_DIR"
-    return 0
-  fi
-
-  if [ -f "$LOCK_PID_FILE" ]; then
-    LOCK_PID=$(cat "$LOCK_PID_FILE" 2>/dev/null)
-    if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
-      log "Execution lock is already held by PID $LOCK_PID"
-      return 2
-    fi
-  fi
-
-  # This stale-lock recovery has a small rm/mkdir race, but that is acceptable here:
-  # release_lock() owns the whole directory via LOCK_PID_FILE, and concurrent cron/hotplug
-  # attempts are designed to fail acquire_lock() and exit successfully instead of surfacing an error.
-  log "Recovering stale execution lock at $LOCK_DIR"
-  rm -rf "$LOCK_DIR" 2>/dev/null || return 1
-
-  mkdir "$LOCK_DIR" 2>/dev/null || return 1
-  printf '%s\n' "$$" > "$LOCK_PID_FILE"
-  printf '%s\n' "$ACTION" > "$LOCK_ACTION_FILE"
-  LOCK_ACQUIRED=1
-  trap 'release_lock' EXIT HUP INT TERM
-  log "Recovered and acquired execution lock at $LOCK_DIR"
+  nordvpn_easy_acquire_lock "$@"
 }
 
 vpn_is_configured () {
-  [ "$(uci -q get "network.${VPN_IF}.proto" 2>/dev/null)" = 'wireguard' ]
+  nordvpn_easy_vpn_is_configured "$@"
 }
 
 vpn_link_is_present () {
-  ip link show dev "$VPN_IF" >/dev/null 2>&1
+  nordvpn_easy_vpn_link_is_present "$@"
 }
 
 log_vpn_interface_state () {
-  STATE_CONTEXT="$1"
-  VPN_PROTO=$(uci -q get "network.${VPN_IF}.proto" 2>/dev/null)
-  VPN_DISABLED=$(uci -q get "network.${VPN_IF}.disabled" 2>/dev/null)
-  VPN_ENDPOINT=$(uci -q get "network.${VPN_IF}server.endpoint_host" 2>/dev/null)
-  VPN_LINK_PRESENT='no'
-
-  ip link show dev "$VPN_IF" >/dev/null 2>&1 && VPN_LINK_PRESENT='yes'
-
-  log "Interface state [$STATE_CONTEXT]: proto=${VPN_PROTO:-absent}, disabled=${VPN_DISABLED:-0}, link_present=$VPN_LINK_PRESENT, endpoint=${VPN_ENDPOINT:-none}"
+  nordvpn_easy_log_vpn_interface_state "$@"
 }
 
 recover_missing_vpn_interface () {
-  log "VPN interface $VPN_IF is still not present after ${VPN_INTERFACE_PRESENT_DELAY}s - starting recovery sequence"
-  log_vpn_interface_state 'missing-interface-start'
-
-  log "Recovery step 1/3: cycling interface $VPN_IF with ifdown/ifup"
-  ifdown "$VPN_IF" >/dev/null 2>&1 || true
-  ifup "$VPN_IF" >/dev/null 2>&1 || true
-  sleep "$VPN_INTERFACE_PRESENT_DELAY"
-
-  if vpn_link_is_present; then
-    log "Recovery step 1/3 succeeded: interface $VPN_IF is present again"
-    log_vpn_interface_state 'missing-interface-after-ifup'
-    return 0
-  fi
-
-  log "Recovery step 2/3: reloading network service because $VPN_IF is still not present"
-  /etc/init.d/network reload || {
-    log 'ERROR: NETWORK RELOAD FAILED DURING MISSING INTERFACE RECOVERY'
-    return 1
-  }
-  sleep "$VPN_INTERFACE_PRESENT_DELAY"
-
-  if vpn_link_is_present; then
-    log "Recovery step 2/3 succeeded: interface $VPN_IF is present again"
-    log_vpn_interface_state 'missing-interface-after-reload'
-    return 0
-  fi
-
-  log "Recovery step 3/3: restarting network service because $VPN_IF is still not present"
-  /etc/init.d/network restart || {
-    log 'ERROR: NETWORK RESTART FAILED DURING MISSING INTERFACE RECOVERY'
-    return 1
-  }
-  sleep "$VPN_INTERFACE_PRESENT_DELAY"
-
-  if vpn_link_is_present; then
-    log "Recovery step 3/3 succeeded: interface $VPN_IF is present again"
-    log_vpn_interface_state 'missing-interface-after-restart'
-    return 0
-  fi
-
-  log "ERROR: VPN interface $VPN_IF is still not present after the full recovery sequence"
-  log_vpn_interface_state 'missing-interface-final'
-  return 1
+  nordvpn_easy_recover_missing_vpn_interface "$@"
 }
 
 ensure_vpn_interface_present () {
-  if vpn_link_is_present; then
-    return 0
-  fi
-
-  log "VPN interface $VPN_IF is not present, waiting ${VPN_INTERFACE_PRESENT_DELAY}s before recovery"
-  log_vpn_interface_state 'missing-interface-before-wait'
-  sleep "$VPN_INTERFACE_PRESENT_DELAY"
-
-  if vpn_link_is_present; then
-    log "VPN interface $VPN_IF became present during the wait window"
-    log_vpn_interface_state 'missing-interface-after-wait'
-    return 0
-  fi
-
-  recover_missing_vpn_interface
+  nordvpn_easy_ensure_vpn_interface_present "$@"
 }
 
 ensure_vpn_interface_enabled () {
-  [ "$(uci -q get "network.${VPN_IF}.disabled" 2>/dev/null)" = '1' ] || return 0
-
-  log "Re-enabling disabled VPN interface $VPN_IF"
-  log_vpn_interface_state 'before-enable'
-  uci -q delete "network.${VPN_IF}.disabled"
-  uci commit network || {
-    log "ERROR: COULD NOT COMMIT NETWORK CONFIGURATION WHILE ENABLING $VPN_IF"
-    return 1
-  }
-
-  /etc/init.d/network reload || {
-    log "ERROR: NETWORK RELOAD FAILED WHILE ENABLING $VPN_IF"
-    return 1
-  }
-
-  ifup "$VPN_IF" || {
-    log "ERROR: IFUP FAILED WHILE ENABLING $VPN_IF"
-    return 1
-  }
-
-  log "VPN interface $VPN_IF has been re-enabled"
-  log_vpn_interface_state 'after-enable'
+  nordvpn_easy_ensure_vpn_interface_enabled "$@"
 }
 
 pick_ping_ip () {
@@ -350,8 +182,7 @@ pick_ping_ip () {
 }
 
 ping_interface () {
-  [ -n "$1" ] || return 1
-  ping -q -c 1 -W 5 "$(pick_ping_ip)" -I "$1" >/dev/null 2>&1
+  nordvpn_easy_ping_interface "$@"
 }
 
 curl_config_escape () {
@@ -720,40 +551,16 @@ fetch_server_catalog () {
   SERVER_CATALOG_URL="${SERVER_CATALOG_URL_BASE}&filters[country_id]=$RESOLVED_COUNTRY_ID"
   log "Refreshing NordVPN server catalog for $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
 
-  curl -g -fsS --connect-timeout 15 --max-time 45 "$SERVER_CATALOG_URL" | jq -ce \
-    --argjson country_id "$RESOLVED_COUNTRY_ID" \
-    --arg country_code "$RESOLVED_COUNTRY_CODE" \
-    --arg country_name "$RESOLVED_COUNTRY_NAME" '
-      {
-        country_id: $country_id,
-        country_code: $country_code,
-        country_name: $country_name,
-        servers: [
-          .[] | {
-            hostname: (.hostname // ""),
-            station: (.station // ""),
-            load: (.load // 0),
-            city: (.locations[0].country.city.name // ""),
-            country_code: (.locations[0].country.code // $country_code),
-            country_name: (.locations[0].country.name // $country_name),
-            public_key: ([.technologies[]? | select(.identifier == "wireguard_udp") | .metadata[]? | select(.name == "public_key") | .value][0] // ""),
-            status: (.status // "")
-          } | select(
-            (.hostname != "") and
-            (.station != "") and
-            (.public_key != "") and
-            (.status != "offline")
-          )
-        ] | sort_by(.load, (.city | ascii_downcase), (.hostname | ascii_downcase))
-      }
-    ' > "$SERVER_CATALOG_TMP" 2>/dev/null || {
+  curl -g -fsS --connect-timeout 15 --max-time 45 "$SERVER_CATALOG_URL" | \
+    nordvpn_easy_build_server_catalog_json "$RESOLVED_COUNTRY_ID" "$RESOLVED_COUNTRY_CODE" "$RESOLVED_COUNTRY_NAME" \
+    > "$SERVER_CATALOG_TMP" 2>/dev/null || {
       rm -f "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
       server_catalog_cache_matches_country "$RESOLVED_COUNTRY_ID" && return 0
       log "ERROR: COULD NOT REFRESH SERVER CATALOG FOR $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
       return 1
     }
 
-  jq -er '.servers[0].station // empty' "$SERVER_CATALOG_TMP" >/dev/null 2>&1 || {
+  nordvpn_easy_server_catalog_has_servers "$SERVER_CATALOG_TMP" || {
     rm -f "$SERVER_CATALOG_TMP" "$SERVER_CATALOG_TS_TMP"
     server_catalog_cache_matches_country "$RESOLVED_COUNTRY_ID" && return 0
     log "ERROR: NO WIREGUARD SERVERS FOUND FOR COUNTRY '$COUNTRY_QUERY'"
@@ -785,585 +592,87 @@ fetch_server_catalog () {
 }
 
 find_preferred_server_in_catalog () {
-  require_manual_server_preference || return 1
-  fetch_server_catalog 0 "$VPN_COUNTRY" || return 1
-
-  PREFERRED_SERVER_LINE=$(jq -er \
-    --arg hostname "$PREFERRED_SERVER_HOSTNAME" \
-    --arg station "$PREFERRED_SERVER_STATION" '
-      [
-        .servers[] | select(
-          (.station == $station) and
-          (($hostname == "") or (.hostname == $hostname))
-        )
-      ][0] | [
-        .hostname,
-        .station,
-        .public_key,
-        .country_code,
-        .city,
-        ((.load // 0) | tostring)
-      ] | @tsv
-    ' "$SERVER_CATALOG_FILE" 2>/dev/null) || {
-      log "ERROR: PREFERRED SERVER $PREFERRED_SERVER_HOSTNAME ($PREFERRED_SERVER_STATION) IS NOT AVAILABLE IN $VPN_COUNTRY"
-      return 1
-    }
+  nordvpn_easy_find_preferred_server_in_catalog "$@"
 }
 
 preferred_server_matches_current () {
-  [ -n "$PREFERRED_SERVER_STATION" ] || return 1
-  [ "$(current_server_station)" = "$PREFERRED_SERVER_STATION" ]
+  nordvpn_easy_preferred_server_matches_current "$@"
 }
 
 apply_preferred_server_from_catalog () {
-  find_preferred_server_in_catalog || return 1
-
-  IFS="$(printf '\t')" read -r HOST_NAME SERVER_IP PUBLIC_KEY COUNTRY_CODE CITY_NAME SERVER_LOAD <<EOF
-$PREFERRED_SERVER_LINE
-EOF
-
-  log "Applying preferred VPN server $HOST_NAME ($SERVER_IP) for $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
-  set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD"
+  nordvpn_easy_apply_preferred_server_from_catalog "$@"
 }
 
 build_server_recommendations_url () {
-  SERVER_RECOMMENDATIONS_URL="$SERVER_RECOMMENDATIONS_URL_BASE"
-
-  if [ -n "$VPN_COUNTRY" ]; then
-    resolve_country_filter || return 1
-    SERVER_RECOMMENDATIONS_URL="${SERVER_RECOMMENDATIONS_URL}&filters[country_id]=$RESOLVED_COUNTRY_ID"
-    log "Building recommendations URL for country filter $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
-  else
-    log 'Building recommendations URL with automatic country selection'
-  fi
-
-  printf '%s\n' "$SERVER_RECOMMENDATIONS_URL"
+  nordvpn_easy_build_server_recommendations_url "$@"
 }
 
 get_servers_list () {
-  SERVER_LIST_TMP="${SERVER_LIST_FILE}.tmp.$$"
-  SERVER_RECOMMENDATIONS_URL=$(build_server_recommendations_url) || return 1
-
-  log "Downloading recommended VPN server list to $SERVER_LIST_TMP"
-
-  curl -g -fsS --connect-timeout 15 --max-time 30 -o "$SERVER_LIST_TMP" "$SERVER_RECOMMENDATIONS_URL" || {
-    rm -f "$SERVER_LIST_TMP"
-    log 'ERROR: COULD NOT RETRIEVE VPN SERVERS'
-    return 1
-  }
-
-  jq -er '.[0].station // empty' "$SERVER_LIST_TMP" >/dev/null 2>&1 || {
-    rm -f "$SERVER_LIST_TMP"
-    if [ -n "$VPN_COUNTRY" ]; then
-      log "ERROR: NO WIREGUARD SERVERS FOUND FOR COUNTRY '$VPN_COUNTRY'"
-    else
-      log 'ERROR: INVALID VPN SERVER LIST'
-    fi
-    return 1
-  }
-
-  mv "$SERVER_LIST_TMP" "$SERVER_LIST_FILE" || {
-    rm -f "$SERVER_LIST_TMP"
-    log 'ERROR: COULD NOT UPDATE VPN SERVER LIST'
-    return 1
-  }
-
-  SERVER_COUNT=$(jq -r 'length' "$SERVER_LIST_FILE" 2>/dev/null)
-  log "VPN server list updated at $SERVER_LIST_FILE with ${SERVER_COUNT:-unknown} entries"
+  nordvpn_easy_get_servers_list "$@"
 }
 
 resolve_wan_device () {
-  WAN_DEVICE=''
-
-  if command -v ubus >/dev/null 2>&1; then
-    WAN_DEVICE=$(ubus call "network.interface.${WAN_IF}" status 2>/dev/null | jq -er '.l3_device // .device // empty' 2>/dev/null)
-    [ -n "$WAN_DEVICE" ] && return 0
-  fi
-
-  WAN_DEVICE=$(uci -q get "network.${WAN_IF}.device" 2>/dev/null)
-  [ -n "$WAN_DEVICE" ] && return 0
-
-  WAN_DEVICE=$(uci -q get "network.${WAN_IF}.ifname" 2>/dev/null)
-  [ -n "$WAN_DEVICE" ] && return 0
-
-  if ip link show dev "$WAN_IF" >/dev/null 2>&1; then
-    WAN_DEVICE="$WAN_IF"
-    return 0
-  fi
-
-  log "ERROR: COULD NOT RESOLVE DEVICE FOR $WAN_IF"
-  return 1
+  nordvpn_easy_resolve_wan_device "$@"
 }
 
 ping_wan () {
-  resolve_wan_device || return 1
-  ping_interface "$WAN_DEVICE"
+  nordvpn_easy_ping_wan "$@"
 }
 
 find_firewall_zone_section () {
-  TARGET_NETWORK="$1"
-
-  for FIREWALL_SECTION in $(uci show firewall | awk -F= '$2=="zone"{ print $1 }'); do
-    ZONE_NETWORKS=$(uci -q get "${FIREWALL_SECTION}.network" 2>/dev/null)
-
-    for ZONE_NETWORK in $ZONE_NETWORKS; do
-      [ "$ZONE_NETWORK" = "$TARGET_NETWORK" ] && {
-        printf '%s\n' "$FIREWALL_SECTION"
-        return 0
-      }
-    done
-  done
-
-  return 1
+  nordvpn_easy_find_firewall_zone_section "$@"
 }
 
 ensure_vpn_in_wan_zone () {
-  WAN_ZONE=$(find_firewall_zone_section "$WAN_IF") || {
-    log "ERROR: FIREWALL ZONE FOR $WAN_IF NOT FOUND"
-    return 1
-  }
-
-  FIREWALL_CHANGED=0
-
-  for FIREWALL_SECTION in $(uci show firewall | awk -F= '$2=="zone"{ print $1 }'); do
-    [ "$FIREWALL_SECTION" = "$WAN_ZONE" ] && continue
-
-    ZONE_NETWORKS=$(uci -q get "${FIREWALL_SECTION}.network" 2>/dev/null)
-    for ZONE_NETWORK in $ZONE_NETWORKS; do
-      [ "$ZONE_NETWORK" = "$VPN_IF" ] || continue
-      uci -q del_list "${FIREWALL_SECTION}.network"="$VPN_IF"
-      FIREWALL_CHANGED=1
-      break
-    done
-  done
-
-  ZONE_HAS_VPN=0
-  ZONE_NETWORKS=$(uci -q get "${WAN_ZONE}.network" 2>/dev/null)
-
-  for ZONE_NETWORK in $ZONE_NETWORKS; do
-    [ "$ZONE_NETWORK" = "$VPN_IF" ] && {
-      ZONE_HAS_VPN=1
-      break
-    }
-  done
-
-  if [ "$ZONE_HAS_VPN" -ne 1 ]; then
-    uci add_list "${WAN_ZONE}.network"="$VPN_IF"
-    FIREWALL_CHANGED=1
-  fi
-
-  if [ "$FIREWALL_CHANGED" -ne 1 ]; then
-    log "Firewall zone for $WAN_IF already contains $VPN_IF"
-    return 0
-  fi
-
-  uci commit firewall || {
-    log 'ERROR: COULD NOT COMMIT FIREWALL CONFIGURATION'
-    return 1
-  }
-
-  /etc/init.d/firewall restart || {
-    log 'ERROR: FIREWALL RESTART FAILED'
-    return 1
-  }
-
-  log "Firewall updated so zone for $WAN_IF includes $VPN_IF"
+  nordvpn_easy_ensure_vpn_in_wan_zone "$@"
 }
 
 set_vpn_server_in_uci () {
-  [ -n "$2" ] || {
-    log 'ERROR: VPN SERVER IP IS EMPTY'
-    return 1
-  }
-  [ -n "$3" ] || {
-    log "ERROR: VPN PUBLIC KEY IS EMPTY FOR $1"
-    return 1
-  }
-
-  uci set "network.${VPN_IF}server.description"="$1"
-  uci set "network.${VPN_IF}server.endpoint_host"="$2"
-  uci set "network.${VPN_IF}server.public_key"="$3"
-  uci set "network.${VPN_IF}server.nordvpn_hostname"="$1"
-  uci set "network.${VPN_IF}server.nordvpn_station"="$2"
-  uci set "network.${VPN_IF}server.nordvpn_country_code"="${4:-}"
-  uci set "network.${VPN_IF}server.nordvpn_city"="${5:-}"
-  uci set "network.${VPN_IF}server.nordvpn_load"="${6:-}"
-  log "Prepared VPN peer update for server $1 ($2)"
+  nordvpn_easy_set_vpn_server_in_uci "$@"
 }
 
 set_first_server_from_list () {
-  FIRST_SERVER=$(jq -r '.[0] | [
-    .hostname,
-    .station,
-    ([.technologies[]?.metadata[]? | select(.name=="public_key").value][0]),
-    (.locations[0].country.code // ""),
-    (.locations[0].country.city.name // ""),
-    ((.load // 0) | tostring)
-  ] | @tsv' "$SERVER_LIST_FILE" 2>/dev/null) || {
-    log 'ERROR: INVALID VPN SERVER LIST'
-    return 1
-  }
-
-  [ -n "$FIRST_SERVER" ] || {
-    log 'ERROR: VPN SERVER LIST IS EMPTY'
-    return 1
-  }
-
-  IFS="$(printf '\t')" read -r HOST_NAME SERVER_IP PUBLIC_KEY COUNTRY_CODE CITY_NAME SERVER_LOAD <<EOF
-$FIRST_SERVER
-EOF
-
-  log "Selected first recommended VPN server $HOST_NAME ($SERVER_IP)"
-  set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD"
+  nordvpn_easy_set_first_server_from_list "$@"
 }
 
 current_server_matches_recommendations () {
-  CURRENT_SERVER=$(current_server_station)
-
-  [ -n "$CURRENT_SERVER" ] || return 1
-
-  jq -e --arg current "$CURRENT_SERVER" '
-    [ .[] | select(.station == $current) ] | length > 0
-  ' "$SERVER_LIST_FILE" >/dev/null 2>&1
+  nordvpn_easy_current_server_matches_recommendations "$@"
 }
 
 apply_server_change_runtime () {
-  if [ "$1" = 'reload' ]; then
-    log "Cycling VPN interface $VPN_IF to apply the new peer configuration"
-    ifdown "$VPN_IF" >/dev/null 2>&1 || true
-    sleep "$INTERFACE_RESTART_DELAY"
-    ifup "$VPN_IF" || {
-      log "ERROR: IFUP FAILED AFTER CHANGING VPN SERVER ON $VPN_IF"
-      return 1
-    }
-    log "Waiting ${POST_RESTART_DELAY}s after cycling $VPN_IF before validating VPN connectivity"
-  else
-    /etc/init.d/network restart || {
-      log 'ERROR: NETWORK RESTART FAILED'
-      return 1
-    }
-    log "Waiting ${POST_RESTART_DELAY}s after network restart before validating VPN connectivity"
-  fi
-
-  sleep "$POST_RESTART_DELAY"
-
-  if ping_interface "$VPN_IF"; then
-    log 'VPN connection restored'
-    verify_public_country_selection
-    return 0
-  fi
-
-  log 'VPN connection is not OK, trying another server...'
-  return 1
+  nordvpn_easy_apply_server_change_runtime "$@"
 }
 
 change_to_preferred_server () {
-  apply_preferred_server_from_catalog || return 1
-
-  uci commit network || {
-    log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
-    return 1
-  }
-
-  log "VPN server changed to preferred server $PREFERRED_SERVER_HOSTNAME ($PREFERRED_SERVER_STATION)"
-  apply_server_change_runtime "${1:-reload}"
+  nordvpn_easy_change_to_preferred_server "$@"
 }
 
 sync_server_selection () {
-  vpn_is_configured || return 0
-
-  if server_selection_is_manual; then
-    require_manual_server_preference || return 1
-
-    if preferred_server_matches_current; then
-      log 'Current VPN server already matches the preferred manual server'
-      return 0
-    fi
-
-    log 'Current VPN server does not match the preferred manual server, applying preference'
-    change_to_preferred_server reload
-    return $?
-  fi
-
-  get_servers_list || return 1
-
-  if current_server_matches_recommendations; then
-    log 'Current VPN server already matches the selected country/filter'
-    return 0
-  fi
-
-  log 'Current VPN server does not match the selected country/filter, changing server'
-  change_vpn_server reload
+  nordvpn_easy_sync_server_selection "$@"
 }
 
 change_vpn_server () {
-  CURRENT_SERVER=$(current_server_station)
-  SERVER_CANDIDATES_FILE="/tmp/nordvpn.candidates.$$"
-
-  log "Starting VPN server rotation from current endpoint ${CURRENT_SERVER:-none}"
-
-  jq -r '.[] | [
-    .hostname,
-    .station,
-    ([.technologies[]?.metadata[]? | select(.name=="public_key").value][0]),
-    (.locations[0].country.code // ""),
-    (.locations[0].country.city.name // ""),
-    ((.load // 0) | tostring)
-  ] | @tsv' "$SERVER_LIST_FILE" > "$SERVER_CANDIDATES_FILE" 2>/dev/null || {
-    rm -f "$SERVER_CANDIDATES_FILE"
-    log 'ERROR: INVALID VPN SERVER LIST'
-    return 1
-  }
-
-  while IFS="$(printf '\t')" read -r HOST_NAME SERVER_IP PUBLIC_KEY COUNTRY_CODE CITY_NAME SERVER_LOAD; do
-    [ -n "$SERVER_IP" ] || continue
-    [ "$CURRENT_SERVER" = "$SERVER_IP" ] && continue
-
-    log "Trying VPN server candidate $HOST_NAME ($SERVER_IP)"
-
-    set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
-    uci commit network || {
-      rm -f "$SERVER_CANDIDATES_FILE"
-      log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
-      return 1
-    }
-
-    log "VPN server changed to $HOST_NAME ( $SERVER_IP )"
-
-    if apply_server_change_runtime "$1"; then
-      rm -f "$SERVER_CANDIDATES_FILE"
-      return 0
-    fi
-  done < "$SERVER_CANDIDATES_FILE"
-
-  rm -f "$SERVER_CANDIDATES_FILE"
-  log 'NO RECOMMENDED VPN SERVER RESTORED CONNECTIVITY'
-  return 1
+  nordvpn_easy_change_vpn_server "$@"
 }
 
 change_manual_server () {
-  CURRENT_SERVER=$(current_server_station)
-  SERVER_CANDIDATES_FILE="/tmp/nordvpn-manual.candidates.$$"
-
-  require_manual_server_preference || return 1
-  fetch_server_catalog 0 "$VPN_COUNTRY" || return 1
-
-  log "Starting manual VPN server rotation from current endpoint ${CURRENT_SERVER:-none}"
-
-  jq -r '.servers[] | [
-    .hostname,
-    .station,
-    .public_key,
-    .country_code,
-    .city,
-    ((.load // 0) | tostring)
-  ] | @tsv' "$SERVER_CATALOG_FILE" > "$SERVER_CANDIDATES_FILE" 2>/dev/null || {
-    rm -f "$SERVER_CANDIDATES_FILE"
-    log 'ERROR: INVALID SERVER CATALOG'
-    return 1
-  }
-
-  while IFS="$(printf '\t')" read -r HOST_NAME SERVER_IP PUBLIC_KEY COUNTRY_CODE CITY_NAME SERVER_LOAD; do
-    [ -n "$SERVER_IP" ] || continue
-    [ "$CURRENT_SERVER" = "$SERVER_IP" ] && continue
-
-    log "Trying manual VPN server candidate $HOST_NAME ($SERVER_IP)"
-
-    set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
-    uci commit network || {
-      rm -f "$SERVER_CANDIDATES_FILE"
-      log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
-      return 1
-    }
-    if apply_server_change_runtime "$1"; then
-      set_server_preference_in_uci "$HOST_NAME" "$SERVER_IP"
-      uci commit nordvpn_easy || {
-        log 'ERROR: COULD NOT COMMIT MANUAL SERVER PREFERENCE'
-        rm -f "$SERVER_CANDIDATES_FILE"
-        continue
-      }
-
-      PREFERRED_SERVER_HOSTNAME="$HOST_NAME"
-      PREFERRED_SERVER_STATION="$SERVER_IP"
-      log "Manual preferred VPN server updated to $HOST_NAME ($SERVER_IP)"
-      rm -f "$SERVER_CANDIDATES_FILE"
-      return 0
-    fi
-
-    rm -f "$SERVER_CANDIDATES_FILE"
-    continue
-  done < "$SERVER_CANDIDATES_FILE"
-
-  rm -f "$SERVER_CANDIDATES_FILE"
-  log 'NO MANUAL VPN SERVER RESTORED CONNECTIVITY'
-  return 1
+  nordvpn_easy_change_manual_server "$@"
 }
 
 configure_vpn_interface () {
-  log "$VPN_IF NOT CONFIGURED - IT WILL BE CREATED"
-  log "Creating WireGuard interface $VPN_IF with address $VPN_ADDR and endpoint port $VPN_PORT"
-  log_vpn_interface_state 'before-create'
-
-  get_private_key || return 1
-  if server_selection_is_manual; then
-    require_manual_server_preference || return 1
-    fetch_server_catalog 0 "$VPN_COUNTRY" || return 1
-  else
-    get_servers_list || return 1
-  fi
-  ensure_vpn_in_wan_zone || return 1
-
-  uci -q delete "network.${VPN_IF}"
-  uci set "network.${VPN_IF}"='interface'
-  uci set "network.${VPN_IF}.proto"='wireguard'
-  uci add_list "network.${VPN_IF}.addresses"="$VPN_ADDR"
-  uci set "network.${VPN_IF}.private_key"="$PRIVATE_KEY"
-
-  if [ -n "$VPN_DNS1" ] || [ -n "$VPN_DNS2" ]; then
-    uci set "network.${VPN_IF}.peerdns"='0'
-    [ -n "$VPN_DNS1" ] && uci add_list "network.${VPN_IF}.dns"="$VPN_DNS1"
-    [ -n "$VPN_DNS2" ] && uci add_list "network.${VPN_IF}.dns"="$VPN_DNS2"
-  else
-    uci set "network.${VPN_IF}.peerdns"='1'
-  fi
-
-  uci set "network.${VPN_IF}.delegate"='0'
-  uci set "network.${VPN_IF}.force_link"='1'
-
-  uci -q delete "network.${VPN_IF}server"
-  uci set "network.${VPN_IF}server"="wireguard_${VPN_IF}"
-  uci set "network.${VPN_IF}server.endpoint_port"="$VPN_PORT"
-  uci set "network.${VPN_IF}server.persistent_keepalive"='25'
-  uci set "network.${VPN_IF}server.route_allowed_ips"='1'
-  uci add_list "network.${VPN_IF}server.allowed_ips"='0.0.0.0/0'
-
-  if server_selection_is_manual; then
-    apply_preferred_server_from_catalog || return 1
-  else
-    set_first_server_from_list || return 1
-  fi
-
-  uci set "network.${WAN_IF}.metric"='1024'
-  uci commit network || {
-    log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
-    return 1
-  }
-
-  /etc/init.d/network restart || {
-    log 'ERROR: NETWORK RESTART FAILED'
-    return 1
-  }
-
-  log "$VPN_IF CREATED"
-  log_vpn_interface_state 'after-create'
+  nordvpn_easy_configure_vpn_interface "$@"
 }
 
 bootstrap_if_needed () {
-  log "Bootstrapping VPN state for interface $VPN_IF"
-  log_vpn_interface_state 'bootstrap-start'
-  refresh_countries_cache || true
-  if [ -n "$VPN_COUNTRY" ]; then
-    resolve_country_filter || return 1
-  fi
-
-  if ! vpn_is_configured; then
-    configure_vpn_interface || return 1
-  else
-    ensure_vpn_interface_enabled || return 1
-  fi
-
-  ensure_vpn_in_wan_zone || return 1
-  ensure_vpn_interface_present || return 1
-  log "Bootstrap completed for interface $VPN_IF"
-  log_vpn_interface_state 'bootstrap-complete'
+  nordvpn_easy_bootstrap_if_needed "$@"
 }
 
 rotate_action () {
-  log 'Rotate action started'
-  bootstrap_if_needed || return 1
-
-  if server_selection_is_manual; then
-    log 'Changing preferred manual VPN server'
-    change_manual_server reload
-    return $?
-  fi
-
-  get_servers_list || return 1
-  log 'Changing VPN server'
-  change_vpn_server reload
+  nordvpn_easy_rotate_action "$@"
 }
 
 check_once () {
-  # shellcheck disable=SC3043 # OpenWrt /bin/sh is BusyBox ash, which supports local.
-  local failed_pings=0
-  local restart_count=0
-  local max_interface_restarts="${MAX_INTERFACE_RESTARTS:-3}"
-  local retry_delay
-  local backoff_steps
-
-  log "Starting VPN health-check on interface $VPN_IF"
-  if ! server_selection_is_manual; then
-    [ -f "$SERVER_LIST_FILE" ] || get_servers_list || true
-  fi
-
-  while ! ping_interface "$VPN_IF"; do
-    failed_pings=$((failed_pings+1))
-    retry_delay="$FAILURE_RETRY_DELAY"
-    ping_wan || {
-      log "WAN connectivity is down while VPN health-check is failing on $VPN_IF; skipping VPN recovery"
-      return 0
-    }
-
-    if [ "$failed_pings" -gt "$INTERFACE_RESTART_THRESHOLD" ]; then
-      if [ "$restart_count" -ge "$max_interface_restarts" ]; then
-        log "PING FAILED $failed_pings TIMES - RESTART LIMIT REACHED FOR $VPN_IF ($restart_count/$max_interface_restarts)"
-        return 1
-      fi
-
-      restart_count=$((restart_count+1))
-      log "PING FAILED $failed_pings TIMES - RESTARTING $VPN_IF ($restart_count/$max_interface_restarts)"
-      log "Requesting ifdown for interface $VPN_IF during recovery"
-      ifdown "$VPN_IF"
-      sleep "$INTERFACE_RESTART_DELAY"
-      log "Requesting ifup for interface $VPN_IF during recovery"
-      ifup "$VPN_IF"
-      sleep "$POST_RESTART_DELAY"
-      log_vpn_interface_state 'after-recovery-restart'
-    elif [ "$failed_pings" -ge "$SERVER_ROTATE_THRESHOLD" ]; then
-      log "PING FAILED $failed_pings TIMES"
-
-      if server_selection_is_manual; then
-        log 'Manual server selection is enabled; skipping automatic server rotation'
-      else
-        if get_servers_list; then
-          log 'Changing VPN server'
-          change_vpn_server restart && return 0
-        else
-          log 'Refreshing VPN server list failed'
-        fi
-      fi
-
-      log 'Restarting network'
-      /etc/init.d/network restart || {
-        log 'ERROR: NETWORK RESTART FAILED'
-        return 1
-      }
-      sleep "$POST_RESTART_DELAY"
-    fi
-
-    if [ "$failed_pings" -ge "$SERVER_ROTATE_THRESHOLD" ]; then
-      backoff_steps=$((failed_pings - SERVER_ROTATE_THRESHOLD + 1))
-      while [ "$backoff_steps" -gt 0 ]; do
-        retry_delay=$((retry_delay * 2))
-        [ "$retry_delay" -gt "$POST_RESTART_DELAY" ] && retry_delay="$POST_RESTART_DELAY"
-        backoff_steps=$((backoff_steps - 1))
-      done
-    fi
-
-    sleep "$retry_delay"
-  done
-
-  log "VPN health-check passed on interface $VPN_IF"
+  nordvpn_easy_check_once "$@"
 }
 
 ACTION='check'
@@ -1452,7 +761,8 @@ case "$ACTION" in
     refresh_countries_cache 1
     ;;
   server_catalog)
-    fetch_server_catalog "$SERVER_CATALOG_FORCE" "$SERVER_CATALOG_QUERY" && cat "$SERVER_CATALOG_FILE"
+    fetch_server_catalog "$SERVER_CATALOG_FORCE" "$SERVER_CATALOG_QUERY" &&
+      nordvpn_easy_emit_server_catalog_json "$SERVER_CATALOG_FILE" "$SERVER_CATALOG_TS_FILE" "$(server_cache_ttl_value)"
     ;;
   *)
     usage

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
@@ -92,7 +92,12 @@ nordvpn_easy_set_first_server_from_list() {
 	FIRST_SERVER=$(jq -r '.[0] | [
 		.hostname,
 		.station,
-		([.technologies[]?.metadata[]? | select(.name=="public_key").value][0]),
+		([.technologies[]?
+			| select(.identifier == "wireguard_udp")
+			| .metadata[]?
+			| select(.name == "public_key")
+			| (.value // "")
+		][0] // ""),
 		(.locations[0].country.code // ""),
 		(.locations[0].country.city.name // ""),
 		((.load // 0) | tostring)
@@ -233,10 +238,9 @@ nordvpn_easy_change_manual_server() {
 		}
 		if apply_server_change_runtime "$1"; then
 			set_server_preference_in_uci "$HOST_NAME" "$SERVER_IP"
-			uci commit nordvpn_easy || {
-				log 'ERROR: COULD NOT COMMIT MANUAL SERVER PREFERENCE'
-				continue
-			}
+			if ! uci commit nordvpn_easy; then
+				log 'WARNING: COULD NOT COMMIT MANUAL SERVER PREFERENCE; KEEPING WORKING RUNTIME SERVER'
+			fi
 
 			PREFERRED_SERVER_HOSTNAME="$HOST_NAME"
 			PREFERRED_SERVER_STATION="$SERVER_IP"

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
@@ -156,6 +156,7 @@ nordvpn_easy_sync_server_selection() {
 nordvpn_easy_change_vpn_server() {
 	CURRENT_SERVER=$(current_server_station)
 	SERVER_CANDIDATES_FILE="/tmp/nordvpn.candidates.$$"
+	commit_failed=0
 	server_changed=0
 
 	log "Starting VPN server rotation from current endpoint ${CURRENT_SERVER:-none}"
@@ -175,7 +176,8 @@ nordvpn_easy_change_vpn_server() {
 		set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
 		uci commit network || {
 			log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
-			continue
+			commit_failed=1
+			break
 		}
 
 		log "VPN server changed to $HOST_NAME ( $SERVER_IP )"
@@ -188,6 +190,10 @@ nordvpn_easy_change_vpn_server() {
 
 	rm -f "$SERVER_CANDIDATES_FILE"
 
+	if [ "$commit_failed" -eq 1 ]; then
+		return 1
+	fi
+
 	if [ "$server_changed" -eq 1 ]; then
 		return 0
 	fi
@@ -199,6 +205,7 @@ nordvpn_easy_change_vpn_server() {
 nordvpn_easy_change_manual_server() {
 	CURRENT_SERVER=$(current_server_station)
 	SERVER_CANDIDATES_FILE="/tmp/nordvpn-manual.candidates.$$"
+	commit_failed=0
 	server_changed=0
 
 	require_manual_server_preference || return 1
@@ -221,7 +228,8 @@ nordvpn_easy_change_manual_server() {
 		set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
 		uci commit network || {
 			log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
-			continue
+			commit_failed=1
+			break
 		}
 		if apply_server_change_runtime "$1"; then
 			set_server_preference_in_uci "$HOST_NAME" "$SERVER_IP"
@@ -239,6 +247,10 @@ nordvpn_easy_change_manual_server() {
 	done < "$SERVER_CANDIDATES_FILE"
 
 	rm -f "$SERVER_CANDIDATES_FILE"
+
+	if [ "$commit_failed" -eq 1 ]; then
+		return 1
+	fi
 
 	if [ "$server_changed" -eq 1 ]; then
 		return 0

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
@@ -156,6 +156,7 @@ nordvpn_easy_sync_server_selection() {
 nordvpn_easy_change_vpn_server() {
 	CURRENT_SERVER=$(current_server_station)
 	SERVER_CANDIDATES_FILE="/tmp/nordvpn.candidates.$$"
+	server_changed=0
 
 	log "Starting VPN server rotation from current endpoint ${CURRENT_SERVER:-none}"
 
@@ -173,20 +174,24 @@ nordvpn_easy_change_vpn_server() {
 
 		set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
 		uci commit network || {
-			rm -f "$SERVER_CANDIDATES_FILE"
 			log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
-			return 1
+			continue
 		}
 
 		log "VPN server changed to $HOST_NAME ( $SERVER_IP )"
 
 		if apply_server_change_runtime "$1"; then
-			rm -f "$SERVER_CANDIDATES_FILE"
-			return 0
+			server_changed=1
+			break
 		fi
 	done < "$SERVER_CANDIDATES_FILE"
 
 	rm -f "$SERVER_CANDIDATES_FILE"
+
+	if [ "$server_changed" -eq 1 ]; then
+		return 0
+	fi
+
 	log 'NO RECOMMENDED VPN SERVER RESTORED CONNECTIVITY'
 	return 1
 }
@@ -194,6 +199,7 @@ nordvpn_easy_change_vpn_server() {
 nordvpn_easy_change_manual_server() {
 	CURRENT_SERVER=$(current_server_station)
 	SERVER_CANDIDATES_FILE="/tmp/nordvpn-manual.candidates.$$"
+	server_changed=0
 
 	require_manual_server_preference || return 1
 	fetch_server_catalog 0 "$VPN_COUNTRY" || return 1
@@ -215,29 +221,29 @@ nordvpn_easy_change_manual_server() {
 		set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
 		uci commit network || {
 			log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
-			rm -f "$SERVER_CANDIDATES_FILE"
 			continue
 		}
 		if apply_server_change_runtime "$1"; then
 			set_server_preference_in_uci "$HOST_NAME" "$SERVER_IP"
 			uci commit nordvpn_easy || {
 				log 'ERROR: COULD NOT COMMIT MANUAL SERVER PREFERENCE'
-				rm -f "$SERVER_CANDIDATES_FILE"
 				continue
 			}
 
 			PREFERRED_SERVER_HOSTNAME="$HOST_NAME"
 			PREFERRED_SERVER_STATION="$SERVER_IP"
 			log "Manual preferred VPN server updated to $HOST_NAME ($SERVER_IP)"
-			rm -f "$SERVER_CANDIDATES_FILE"
-			return 0
+			server_changed=1
+			break
 		fi
-
-		rm -f "$SERVER_CANDIDATES_FILE"
-		continue
 	done < "$SERVER_CANDIDATES_FILE"
 
 	rm -f "$SERVER_CANDIDATES_FILE"
+
+	if [ "$server_changed" -eq 1 ]; then
+		return 0
+	fi
+
 	log 'NO MANUAL VPN SERVER RESTORED CONNECTIVITY'
 	return 1
 }

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
@@ -1,7 +1,24 @@
 #!/bin/sh
 
+# This module is sourced by core.sh. Some orchestration helpers remain provided
+# by core.sh (for example fetch_server_catalog, resolve_country_filter,
+# refresh_countries_cache and get_private_key), so validate that sourcing
+# contract when these code paths execute.
+
+nordvpn_easy_require_core_action_helpers() {
+	local helper
+
+	for helper in "$@"; do
+		command -v "$helper" >/dev/null 2>&1 || {
+			printf '%s\n' "nordvpn-easy: lib/actions.sh requires helper '$helper' from core.sh before invocation" >&2
+			return 1
+		}
+	done
+}
+
 nordvpn_easy_find_preferred_server_in_catalog() {
-	require_manual_server_preference || return 1
+	nordvpn_easy_require_core_action_helpers fetch_server_catalog || return 1
+	nordvpn_easy_require_manual_server_preference || return 1
 	fetch_server_catalog 0 "$VPN_COUNTRY" || return 1
 
 	PREFERRED_SERVER_LINE=$(jq -er \
@@ -28,24 +45,25 @@ nordvpn_easy_find_preferred_server_in_catalog() {
 
 nordvpn_easy_preferred_server_matches_current() {
 	[ -n "$PREFERRED_SERVER_STATION" ] || return 1
-	[ "$(current_server_station)" = "$PREFERRED_SERVER_STATION" ]
+	[ "$(nordvpn_easy_current_server_station)" = "$PREFERRED_SERVER_STATION" ]
 }
 
 nordvpn_easy_apply_preferred_server_from_catalog() {
-	find_preferred_server_in_catalog || return 1
+	nordvpn_easy_find_preferred_server_in_catalog || return 1
 
 	IFS="$(printf '\t')" read -r HOST_NAME SERVER_IP PUBLIC_KEY COUNTRY_CODE CITY_NAME SERVER_LOAD <<EOF
 $PREFERRED_SERVER_LINE
 EOF
 
 	log "Applying preferred VPN server $HOST_NAME ($SERVER_IP) for $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
-	set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD"
+	nordvpn_easy_set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD"
 }
 
 nordvpn_easy_build_server_recommendations_url() {
 	SERVER_RECOMMENDATIONS_URL="$SERVER_RECOMMENDATIONS_URL_BASE"
 
 	if [ -n "$VPN_COUNTRY" ]; then
+		nordvpn_easy_require_core_action_helpers resolve_country_filter || return 1
 		resolve_country_filter || return 1
 		SERVER_RECOMMENDATIONS_URL="${SERVER_RECOMMENDATIONS_URL}&filters[country_id]=$RESOLVED_COUNTRY_ID"
 		log "Building recommendations URL for country filter $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
@@ -58,7 +76,7 @@ nordvpn_easy_build_server_recommendations_url() {
 
 nordvpn_easy_get_servers_list() {
 	SERVER_LIST_TMP="${SERVER_LIST_FILE}.tmp.$$"
-	SERVER_RECOMMENDATIONS_URL=$(build_server_recommendations_url) || return 1
+	SERVER_RECOMMENDATIONS_URL=$(nordvpn_easy_build_server_recommendations_url) || return 1
 
 	log "Downloading recommended VPN server list to $SERVER_LIST_TMP"
 
@@ -116,11 +134,11 @@ $FIRST_SERVER
 EOF
 
 	log "Selected first recommended VPN server $HOST_NAME ($SERVER_IP)"
-	set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD"
+	nordvpn_easy_set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD"
 }
 
 nordvpn_easy_change_to_preferred_server() {
-	apply_preferred_server_from_catalog || return 1
+	nordvpn_easy_apply_preferred_server_from_catalog || return 1
 
 	uci commit network || {
 		log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
@@ -128,38 +146,38 @@ nordvpn_easy_change_to_preferred_server() {
 	}
 
 	log "VPN server changed to preferred server $PREFERRED_SERVER_HOSTNAME ($PREFERRED_SERVER_STATION)"
-	apply_server_change_runtime "${1:-reload}"
+	nordvpn_easy_apply_server_change_runtime "${1:-reload}"
 }
 
 nordvpn_easy_sync_server_selection() {
-	vpn_is_configured || return 0
+	nordvpn_easy_vpn_is_configured || return 0
 
-	if server_selection_is_manual; then
-		require_manual_server_preference || return 1
+	if nordvpn_easy_server_selection_is_manual; then
+		nordvpn_easy_require_manual_server_preference || return 1
 
-		if preferred_server_matches_current; then
+		if nordvpn_easy_preferred_server_matches_current; then
 			log 'Current VPN server already matches the preferred manual server'
 			return 0
 		fi
 
 		log 'Current VPN server does not match the preferred manual server, applying preference'
-		change_to_preferred_server reload
+		nordvpn_easy_change_to_preferred_server reload
 		return $?
 	fi
 
-	get_servers_list || return 1
+	nordvpn_easy_get_servers_list || return 1
 
-	if current_server_matches_recommendations; then
+	if nordvpn_easy_current_server_matches_recommendations; then
 		log 'Current VPN server already matches the selected country/filter'
 		return 0
 	fi
 
 	log 'Current VPN server does not match the selected country/filter, changing server'
-	change_vpn_server reload
+	nordvpn_easy_change_vpn_server reload
 }
 
 nordvpn_easy_change_vpn_server() {
-	CURRENT_SERVER=$(current_server_station)
+	CURRENT_SERVER=$(nordvpn_easy_current_server_station)
 	SERVER_CANDIDATES_FILE="/tmp/nordvpn.candidates.$$"
 	commit_failed=0
 	server_changed=0
@@ -178,7 +196,7 @@ nordvpn_easy_change_vpn_server() {
 
 		log "Trying VPN server candidate $HOST_NAME ($SERVER_IP)"
 
-		set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
+		nordvpn_easy_set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
 		uci commit network || {
 			log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
 			commit_failed=1
@@ -187,7 +205,7 @@ nordvpn_easy_change_vpn_server() {
 
 		log "VPN server changed to $HOST_NAME ( $SERVER_IP )"
 
-		if apply_server_change_runtime "$1"; then
+		if nordvpn_easy_apply_server_change_runtime "$1"; then
 			server_changed=1
 			break
 		fi
@@ -208,12 +226,12 @@ nordvpn_easy_change_vpn_server() {
 }
 
 nordvpn_easy_change_manual_server() {
-	CURRENT_SERVER=$(current_server_station)
+	CURRENT_SERVER=$(nordvpn_easy_current_server_station)
 	SERVER_CANDIDATES_FILE="/tmp/nordvpn-manual.candidates.$$"
 	commit_failed=0
 	server_changed=0
 
-	require_manual_server_preference || return 1
+	nordvpn_easy_require_manual_server_preference || return 1
 	fetch_server_catalog 0 "$VPN_COUNTRY" || return 1
 
 	log "Starting manual VPN server rotation from current endpoint ${CURRENT_SERVER:-none}"
@@ -230,14 +248,14 @@ nordvpn_easy_change_manual_server() {
 
 		log "Trying manual VPN server candidate $HOST_NAME ($SERVER_IP)"
 
-		set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
+		nordvpn_easy_set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
 		uci commit network || {
 			log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
 			commit_failed=1
 			break
 		}
-		if apply_server_change_runtime "$1"; then
-			set_server_preference_in_uci "$HOST_NAME" "$SERVER_IP"
+		if nordvpn_easy_apply_server_change_runtime "$1"; then
+			nordvpn_easy_set_server_preference_in_uci "$HOST_NAME" "$SERVER_IP"
 			if ! uci commit nordvpn_easy; then
 				log 'WARNING: COULD NOT COMMIT MANUAL SERVER PREFERENCE; KEEPING WORKING RUNTIME SERVER'
 			fi
@@ -265,18 +283,20 @@ nordvpn_easy_change_manual_server() {
 }
 
 nordvpn_easy_configure_vpn_interface() {
+	nordvpn_easy_require_core_action_helpers get_private_key || return 1
 	log "$VPN_IF NOT CONFIGURED - IT WILL BE CREATED"
-	log_vpn_interface_state 'before-create'
+	nordvpn_easy_log_vpn_interface_state 'before-create'
 	log "Creating WireGuard interface $VPN_IF with address $VPN_ADDR and endpoint port $VPN_PORT"
 
 	get_private_key || return 1
-	if server_selection_is_manual; then
-		require_manual_server_preference || return 1
+	if nordvpn_easy_server_selection_is_manual; then
+		nordvpn_easy_require_core_action_helpers fetch_server_catalog || return 1
+		nordvpn_easy_require_manual_server_preference || return 1
 		fetch_server_catalog 0 "$VPN_COUNTRY" || return 1
 	else
-		get_servers_list || return 1
+		nordvpn_easy_get_servers_list || return 1
 	fi
-	ensure_vpn_in_wan_zone || return 1
+	nordvpn_easy_ensure_vpn_in_wan_zone || return 1
 
 	uci -q delete "network.${VPN_IF}"
 	uci set "network.${VPN_IF}"='interface'
@@ -302,10 +322,10 @@ nordvpn_easy_configure_vpn_interface() {
 	uci set "network.${VPN_IF}server.route_allowed_ips"='1'
 	uci add_list "network.${VPN_IF}server.allowed_ips"='0.0.0.0/0'
 
-	if server_selection_is_manual; then
-		apply_preferred_server_from_catalog || return 1
+	if nordvpn_easy_server_selection_is_manual; then
+		nordvpn_easy_apply_preferred_server_from_catalog || return 1
 	else
-		set_first_server_from_list || return 1
+		nordvpn_easy_set_first_server_from_list || return 1
 	fi
 
 	uci set "network.${WAN_IF}.metric"='1024'
@@ -320,42 +340,44 @@ nordvpn_easy_configure_vpn_interface() {
 	}
 
 	log "$VPN_IF CREATED"
-	log_vpn_interface_state 'after-create'
+	nordvpn_easy_log_vpn_interface_state 'after-create'
 }
 
 nordvpn_easy_bootstrap_if_needed() {
+	nordvpn_easy_require_core_action_helpers refresh_countries_cache || return 1
 	log "Bootstrapping VPN state for interface $VPN_IF"
-	log_vpn_interface_state 'bootstrap-start'
+	nordvpn_easy_log_vpn_interface_state 'bootstrap-start'
 	refresh_countries_cache || true
 	if [ -n "$VPN_COUNTRY" ]; then
+		nordvpn_easy_require_core_action_helpers resolve_country_filter || return 1
 		resolve_country_filter || return 1
 	fi
 
-	if ! vpn_is_configured; then
-		configure_vpn_interface || return 1
+	if ! nordvpn_easy_vpn_is_configured; then
+		nordvpn_easy_configure_vpn_interface || return 1
 	else
-		ensure_vpn_interface_enabled || return 1
+		nordvpn_easy_ensure_vpn_interface_enabled || return 1
 	fi
 
-	ensure_vpn_in_wan_zone || return 1
-	ensure_vpn_interface_present || return 1
+	nordvpn_easy_ensure_vpn_in_wan_zone || return 1
+	nordvpn_easy_ensure_vpn_interface_present || return 1
 	log "Bootstrap completed for interface $VPN_IF"
-	log_vpn_interface_state 'bootstrap-complete'
+	nordvpn_easy_log_vpn_interface_state 'bootstrap-complete'
 }
 
 nordvpn_easy_rotate_action() {
 	log 'Rotate action started'
-	bootstrap_if_needed || return 1
+	nordvpn_easy_bootstrap_if_needed || return 1
 
-	if server_selection_is_manual; then
+	if nordvpn_easy_server_selection_is_manual; then
 		log 'Changing preferred manual VPN server'
-		change_manual_server reload
+		nordvpn_easy_change_manual_server reload
 		return $?
 	fi
 
-	get_servers_list || return 1
+	nordvpn_easy_get_servers_list || return 1
 	log 'Changing VPN server'
-	change_vpn_server reload
+	nordvpn_easy_change_vpn_server reload
 }
 
 nordvpn_easy_check_once() {
@@ -367,14 +389,14 @@ nordvpn_easy_check_once() {
 	local backoff_steps
 
 	log "Starting VPN health-check on interface $VPN_IF"
-	if ! server_selection_is_manual; then
-		[ -f "$SERVER_LIST_FILE" ] || get_servers_list || true
+	if ! nordvpn_easy_server_selection_is_manual; then
+		[ -f "$SERVER_LIST_FILE" ] || nordvpn_easy_get_servers_list || true
 	fi
 
-	while ! ping_interface "$VPN_IF"; do
+	while ! nordvpn_easy_ping_interface "$VPN_IF"; do
 		failed_pings=$((failed_pings+1))
 		retry_delay="$FAILURE_RETRY_DELAY"
-		ping_wan || {
+		nordvpn_easy_ping_wan || {
 			log "WAN connectivity is down while VPN health-check is failing on $VPN_IF; skipping VPN recovery"
 			return 0
 		}
@@ -393,19 +415,19 @@ nordvpn_easy_check_once() {
 			log "Requesting ifup for interface $VPN_IF during recovery"
 			ifup "$VPN_IF"
 			sleep "$POST_RESTART_DELAY"
-			log_vpn_interface_state 'after-recovery-restart'
-		elif [ "$failed_pings" -ge "$SERVER_ROTATE_THRESHOLD" ]; then
-			log "PING FAILED $failed_pings TIMES"
+				nordvpn_easy_log_vpn_interface_state 'after-recovery-restart'
+			elif [ "$failed_pings" -ge "$SERVER_ROTATE_THRESHOLD" ]; then
+				log "PING FAILED $failed_pings TIMES"
 
-			if server_selection_is_manual; then
-				log 'Manual server selection is enabled; skipping automatic server rotation'
-			else
-				if get_servers_list; then
-					log 'Changing VPN server'
-					change_vpn_server restart && return 0
+				if nordvpn_easy_server_selection_is_manual; then
+					log 'Manual server selection is enabled; skipping automatic server rotation'
 				else
-					log 'Refreshing VPN server list failed'
-				fi
+					if nordvpn_easy_get_servers_list; then
+						log 'Changing VPN server'
+						nordvpn_easy_change_vpn_server restart && return 0
+					else
+						log 'Refreshing VPN server list failed'
+					fi
 			fi
 
 			log 'Restarting network'

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
@@ -1,0 +1,410 @@
+#!/bin/sh
+
+nordvpn_easy_find_preferred_server_in_catalog() {
+	require_manual_server_preference || return 1
+	fetch_server_catalog 0 "$VPN_COUNTRY" || return 1
+
+	PREFERRED_SERVER_LINE=$(jq -er \
+		--arg hostname "$PREFERRED_SERVER_HOSTNAME" \
+		--arg station "$PREFERRED_SERVER_STATION" '
+			[
+				.servers[] | select(
+					(.station == $station) and
+					(($hostname == "") or (.hostname == $hostname))
+				)
+			][0] | [
+				.hostname,
+				.station,
+				.public_key,
+				.country_code,
+				.city,
+				((.load // 0) | tostring)
+			] | @tsv
+		' "$SERVER_CATALOG_FILE" 2>/dev/null) || {
+			log "ERROR: PREFERRED SERVER $PREFERRED_SERVER_HOSTNAME ($PREFERRED_SERVER_STATION) IS NOT AVAILABLE IN $VPN_COUNTRY"
+			return 1
+		}
+}
+
+nordvpn_easy_preferred_server_matches_current() {
+	[ -n "$PREFERRED_SERVER_STATION" ] || return 1
+	[ "$(current_server_station)" = "$PREFERRED_SERVER_STATION" ]
+}
+
+nordvpn_easy_apply_preferred_server_from_catalog() {
+	find_preferred_server_in_catalog || return 1
+
+	IFS="$(printf '\t')" read -r HOST_NAME SERVER_IP PUBLIC_KEY COUNTRY_CODE CITY_NAME SERVER_LOAD <<EOF
+$PREFERRED_SERVER_LINE
+EOF
+
+	log "Applying preferred VPN server $HOST_NAME ($SERVER_IP) for $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
+	set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD"
+}
+
+nordvpn_easy_build_server_recommendations_url() {
+	SERVER_RECOMMENDATIONS_URL="$SERVER_RECOMMENDATIONS_URL_BASE"
+
+	if [ -n "$VPN_COUNTRY" ]; then
+		resolve_country_filter || return 1
+		SERVER_RECOMMENDATIONS_URL="${SERVER_RECOMMENDATIONS_URL}&filters[country_id]=$RESOLVED_COUNTRY_ID"
+		log "Building recommendations URL for country filter $RESOLVED_COUNTRY_NAME ($RESOLVED_COUNTRY_CODE)"
+	else
+		log 'Building recommendations URL with automatic country selection'
+	fi
+
+	printf '%s\n' "$SERVER_RECOMMENDATIONS_URL"
+}
+
+nordvpn_easy_get_servers_list() {
+	SERVER_LIST_TMP="${SERVER_LIST_FILE}.tmp.$$"
+	SERVER_RECOMMENDATIONS_URL=$(build_server_recommendations_url) || return 1
+
+	log "Downloading recommended VPN server list to $SERVER_LIST_TMP"
+
+	curl -g -fsS --connect-timeout 15 --max-time 30 -o "$SERVER_LIST_TMP" "$SERVER_RECOMMENDATIONS_URL" || {
+		rm -f "$SERVER_LIST_TMP"
+		log 'ERROR: COULD NOT RETRIEVE VPN SERVERS'
+		return 1
+	}
+
+	jq -er '.[0].station // empty' "$SERVER_LIST_TMP" >/dev/null 2>&1 || {
+		rm -f "$SERVER_LIST_TMP"
+		if [ -n "$VPN_COUNTRY" ]; then
+			log "ERROR: NO WIREGUARD SERVERS FOUND FOR COUNTRY '$VPN_COUNTRY'"
+		else
+			log 'ERROR: INVALID VPN SERVER LIST'
+		fi
+		return 1
+	}
+
+	mv "$SERVER_LIST_TMP" "$SERVER_LIST_FILE" || {
+		rm -f "$SERVER_LIST_TMP"
+		log 'ERROR: COULD NOT UPDATE VPN SERVER LIST'
+		return 1
+	}
+
+	SERVER_COUNT=$(jq -r 'length' "$SERVER_LIST_FILE" 2>/dev/null)
+	log "VPN server list updated at $SERVER_LIST_FILE with ${SERVER_COUNT:-unknown} entries"
+}
+
+nordvpn_easy_set_first_server_from_list() {
+	FIRST_SERVER=$(jq -r '.[0] | [
+		.hostname,
+		.station,
+		([.technologies[]?.metadata[]? | select(.name=="public_key").value][0]),
+		(.locations[0].country.code // ""),
+		(.locations[0].country.city.name // ""),
+		((.load // 0) | tostring)
+	] | @tsv' "$SERVER_LIST_FILE" 2>/dev/null) || {
+		log 'ERROR: INVALID VPN SERVER LIST'
+		return 1
+	}
+
+	[ -n "$FIRST_SERVER" ] || {
+		log 'ERROR: VPN SERVER LIST IS EMPTY'
+		return 1
+	}
+
+	IFS="$(printf '\t')" read -r HOST_NAME SERVER_IP PUBLIC_KEY COUNTRY_CODE CITY_NAME SERVER_LOAD <<EOF
+$FIRST_SERVER
+EOF
+
+	log "Selected first recommended VPN server $HOST_NAME ($SERVER_IP)"
+	set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD"
+}
+
+nordvpn_easy_change_to_preferred_server() {
+	apply_preferred_server_from_catalog || return 1
+
+	uci commit network || {
+		log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
+		return 1
+	}
+
+	log "VPN server changed to preferred server $PREFERRED_SERVER_HOSTNAME ($PREFERRED_SERVER_STATION)"
+	apply_server_change_runtime "${1:-reload}"
+}
+
+nordvpn_easy_sync_server_selection() {
+	vpn_is_configured || return 0
+
+	if server_selection_is_manual; then
+		require_manual_server_preference || return 1
+
+		if preferred_server_matches_current; then
+			log 'Current VPN server already matches the preferred manual server'
+			return 0
+		fi
+
+		log 'Current VPN server does not match the preferred manual server, applying preference'
+		change_to_preferred_server reload
+		return $?
+	fi
+
+	get_servers_list || return 1
+
+	if current_server_matches_recommendations; then
+		log 'Current VPN server already matches the selected country/filter'
+		return 0
+	fi
+
+	log 'Current VPN server does not match the selected country/filter, changing server'
+	change_vpn_server reload
+}
+
+nordvpn_easy_change_vpn_server() {
+	CURRENT_SERVER=$(current_server_station)
+	SERVER_CANDIDATES_FILE="/tmp/nordvpn.candidates.$$"
+
+	log "Starting VPN server rotation from current endpoint ${CURRENT_SERVER:-none}"
+
+	nordvpn_easy_recommendation_candidates_tsv "$SERVER_LIST_FILE" > "$SERVER_CANDIDATES_FILE" || {
+		rm -f "$SERVER_CANDIDATES_FILE"
+		log 'ERROR: INVALID VPN SERVER LIST'
+		return 1
+	}
+
+	while IFS="$(printf '\t')" read -r HOST_NAME SERVER_IP PUBLIC_KEY COUNTRY_CODE CITY_NAME SERVER_LOAD; do
+		[ -n "$SERVER_IP" ] || continue
+		[ "$CURRENT_SERVER" = "$SERVER_IP" ] && continue
+
+		log "Trying VPN server candidate $HOST_NAME ($SERVER_IP)"
+
+		set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
+		uci commit network || {
+			rm -f "$SERVER_CANDIDATES_FILE"
+			log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
+			return 1
+		}
+
+		log "VPN server changed to $HOST_NAME ( $SERVER_IP )"
+
+		if apply_server_change_runtime "$1"; then
+			rm -f "$SERVER_CANDIDATES_FILE"
+			return 0
+		fi
+	done < "$SERVER_CANDIDATES_FILE"
+
+	rm -f "$SERVER_CANDIDATES_FILE"
+	log 'NO RECOMMENDED VPN SERVER RESTORED CONNECTIVITY'
+	return 1
+}
+
+nordvpn_easy_change_manual_server() {
+	CURRENT_SERVER=$(current_server_station)
+	SERVER_CANDIDATES_FILE="/tmp/nordvpn-manual.candidates.$$"
+
+	require_manual_server_preference || return 1
+	fetch_server_catalog 0 "$VPN_COUNTRY" || return 1
+
+	log "Starting manual VPN server rotation from current endpoint ${CURRENT_SERVER:-none}"
+
+	nordvpn_easy_server_catalog_candidates_tsv "$SERVER_CATALOG_FILE" > "$SERVER_CANDIDATES_FILE" || {
+		rm -f "$SERVER_CANDIDATES_FILE"
+		log 'ERROR: INVALID SERVER CATALOG'
+		return 1
+	}
+
+	while IFS="$(printf '\t')" read -r HOST_NAME SERVER_IP PUBLIC_KEY COUNTRY_CODE CITY_NAME SERVER_LOAD; do
+		[ -n "$SERVER_IP" ] || continue
+		[ "$CURRENT_SERVER" = "$SERVER_IP" ] && continue
+
+		log "Trying manual VPN server candidate $HOST_NAME ($SERVER_IP)"
+
+		set_vpn_server_in_uci "$HOST_NAME" "$SERVER_IP" "$PUBLIC_KEY" "$COUNTRY_CODE" "$CITY_NAME" "$SERVER_LOAD" || continue
+		uci commit network || {
+			log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
+			rm -f "$SERVER_CANDIDATES_FILE"
+			continue
+		}
+		if apply_server_change_runtime "$1"; then
+			set_server_preference_in_uci "$HOST_NAME" "$SERVER_IP"
+			uci commit nordvpn_easy || {
+				log 'ERROR: COULD NOT COMMIT MANUAL SERVER PREFERENCE'
+				rm -f "$SERVER_CANDIDATES_FILE"
+				continue
+			}
+
+			PREFERRED_SERVER_HOSTNAME="$HOST_NAME"
+			PREFERRED_SERVER_STATION="$SERVER_IP"
+			log "Manual preferred VPN server updated to $HOST_NAME ($SERVER_IP)"
+			rm -f "$SERVER_CANDIDATES_FILE"
+			return 0
+		fi
+
+		rm -f "$SERVER_CANDIDATES_FILE"
+		continue
+	done < "$SERVER_CANDIDATES_FILE"
+
+	rm -f "$SERVER_CANDIDATES_FILE"
+	log 'NO MANUAL VPN SERVER RESTORED CONNECTIVITY'
+	return 1
+}
+
+nordvpn_easy_configure_vpn_interface() {
+	log "$VPN_IF NOT CONFIGURED - IT WILL BE CREATED"
+	log_vpn_interface_state 'before-create'
+	log "Creating WireGuard interface $VPN_IF with address $VPN_ADDR and endpoint port $VPN_PORT"
+
+	get_private_key || return 1
+	if server_selection_is_manual; then
+		require_manual_server_preference || return 1
+		fetch_server_catalog 0 "$VPN_COUNTRY" || return 1
+	else
+		get_servers_list || return 1
+	fi
+	ensure_vpn_in_wan_zone || return 1
+
+	uci -q delete "network.${VPN_IF}"
+	uci set "network.${VPN_IF}"='interface'
+	uci set "network.${VPN_IF}.proto"='wireguard'
+	uci add_list "network.${VPN_IF}.addresses"="$VPN_ADDR"
+	uci set "network.${VPN_IF}.private_key"="$PRIVATE_KEY"
+
+	if [ -n "$VPN_DNS1" ] || [ -n "$VPN_DNS2" ]; then
+		uci set "network.${VPN_IF}.peerdns"='0'
+		[ -n "$VPN_DNS1" ] && uci add_list "network.${VPN_IF}.dns"="$VPN_DNS1"
+		[ -n "$VPN_DNS2" ] && uci add_list "network.${VPN_IF}.dns"="$VPN_DNS2"
+	else
+		uci set "network.${VPN_IF}.peerdns"='1'
+	fi
+
+	uci set "network.${VPN_IF}.delegate"='0'
+	uci set "network.${VPN_IF}.force_link"='1'
+
+	uci -q delete "network.${VPN_IF}server"
+	uci set "network.${VPN_IF}server"="wireguard_${VPN_IF}"
+	uci set "network.${VPN_IF}server.endpoint_port"="$VPN_PORT"
+	uci set "network.${VPN_IF}server.persistent_keepalive"='25'
+	uci set "network.${VPN_IF}server.route_allowed_ips"='1'
+	uci add_list "network.${VPN_IF}server.allowed_ips"='0.0.0.0/0'
+
+	if server_selection_is_manual; then
+		apply_preferred_server_from_catalog || return 1
+	else
+		set_first_server_from_list || return 1
+	fi
+
+	uci set "network.${WAN_IF}.metric"='1024'
+	uci commit network || {
+		log 'ERROR: COULD NOT COMMIT NETWORK CONFIGURATION'
+		return 1
+	}
+
+	/etc/init.d/network restart || {
+		log 'ERROR: NETWORK RESTART FAILED'
+		return 1
+	}
+
+	log "$VPN_IF CREATED"
+	log_vpn_interface_state 'after-create'
+}
+
+nordvpn_easy_bootstrap_if_needed() {
+	log "Bootstrapping VPN state for interface $VPN_IF"
+	log_vpn_interface_state 'bootstrap-start'
+	refresh_countries_cache || true
+	if [ -n "$VPN_COUNTRY" ]; then
+		resolve_country_filter || return 1
+	fi
+
+	if ! vpn_is_configured; then
+		configure_vpn_interface || return 1
+	else
+		ensure_vpn_interface_enabled || return 1
+	fi
+
+	ensure_vpn_in_wan_zone || return 1
+	ensure_vpn_interface_present || return 1
+	log "Bootstrap completed for interface $VPN_IF"
+	log_vpn_interface_state 'bootstrap-complete'
+}
+
+nordvpn_easy_rotate_action() {
+	log 'Rotate action started'
+	bootstrap_if_needed || return 1
+
+	if server_selection_is_manual; then
+		log 'Changing preferred manual VPN server'
+		change_manual_server reload
+		return $?
+	fi
+
+	get_servers_list || return 1
+	log 'Changing VPN server'
+	change_vpn_server reload
+}
+
+nordvpn_easy_check_once() {
+	# shellcheck disable=SC3043 # OpenWrt /bin/sh is BusyBox ash, which supports local.
+	local failed_pings=0
+	local restart_count=0
+	local max_interface_restarts="${MAX_INTERFACE_RESTARTS:-3}"
+	local retry_delay
+	local backoff_steps
+
+	log "Starting VPN health-check on interface $VPN_IF"
+	if ! server_selection_is_manual; then
+		[ -f "$SERVER_LIST_FILE" ] || get_servers_list || true
+	fi
+
+	while ! ping_interface "$VPN_IF"; do
+		failed_pings=$((failed_pings+1))
+		retry_delay="$FAILURE_RETRY_DELAY"
+		ping_wan || {
+			log "WAN connectivity is down while VPN health-check is failing on $VPN_IF; skipping VPN recovery"
+			return 0
+		}
+
+		if [ "$failed_pings" -gt "$INTERFACE_RESTART_THRESHOLD" ]; then
+			if [ "$restart_count" -ge "$max_interface_restarts" ]; then
+				log "PING FAILED $failed_pings TIMES - RESTART LIMIT REACHED FOR $VPN_IF ($restart_count/$max_interface_restarts)"
+				return 1
+			fi
+
+			restart_count=$((restart_count+1))
+			log "PING FAILED $failed_pings TIMES - RESTARTING $VPN_IF ($restart_count/$max_interface_restarts)"
+			log "Requesting ifdown for interface $VPN_IF during recovery"
+			ifdown "$VPN_IF"
+			sleep "$INTERFACE_RESTART_DELAY"
+			log "Requesting ifup for interface $VPN_IF during recovery"
+			ifup "$VPN_IF"
+			sleep "$POST_RESTART_DELAY"
+			log_vpn_interface_state 'after-recovery-restart'
+		elif [ "$failed_pings" -ge "$SERVER_ROTATE_THRESHOLD" ]; then
+			log "PING FAILED $failed_pings TIMES"
+
+			if server_selection_is_manual; then
+				log 'Manual server selection is enabled; skipping automatic server rotation'
+			else
+				if get_servers_list; then
+					log 'Changing VPN server'
+					change_vpn_server restart && return 0
+				else
+					log 'Refreshing VPN server list failed'
+				fi
+			fi
+
+			log 'Restarting network'
+			/etc/init.d/network restart || {
+				log 'ERROR: NETWORK RESTART FAILED'
+				return 1
+			}
+			sleep "$POST_RESTART_DELAY"
+		fi
+
+		if [ "$failed_pings" -ge "$SERVER_ROTATE_THRESHOLD" ]; then
+			backoff_steps=$((failed_pings - SERVER_ROTATE_THRESHOLD + 1))
+			while [ "$backoff_steps" -gt 0 ]; do
+				retry_delay=$((retry_delay * 2))
+				[ "$retry_delay" -gt "$POST_RESTART_DELAY" ] && retry_delay="$POST_RESTART_DELAY"
+				backoff_steps=$((backoff_steps - 1))
+			done
+		fi
+
+		sleep "$retry_delay"
+	done
+
+	log "VPN health-check passed on interface $VPN_IF"
+}

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+nordvpn_easy_build_server_catalog_json() {
+	local country_id="$1"
+	local country_code="$2"
+	local country_name="$3"
+
+	jq -ce \
+		--argjson country_id "$country_id" \
+		--arg country_code "$country_code" \
+		--arg country_name "$country_name" '
+			{
+				country_id: $country_id,
+				country_code: $country_code,
+				country_name: $country_name,
+				servers: [
+					.[] | {
+						hostname: (.hostname // ""),
+						station: (.station // ""),
+						load: (.load // 0),
+						city: (.locations[0].country.city.name // ""),
+						country_code: (.locations[0].country.code // $country_code),
+						country_name: (.locations[0].country.name // $country_name),
+						public_key: ([.technologies[]? | select(.identifier == "wireguard_udp") | .metadata[]? | select(.name == "public_key") | .value][0] // ""),
+						status: (.status // "")
+					} | select(
+						(.hostname != "") and
+						(.station != "") and
+						(.public_key != "") and
+						(.status != "offline")
+					)
+				] | sort_by(.load, (.city | ascii_downcase), (.hostname | ascii_downcase))
+			}
+		'
+}
+
+nordvpn_easy_server_catalog_has_servers() {
+	jq -er '.servers[0].station // empty' "$1" >/dev/null 2>&1
+}
+
+nordvpn_easy_server_catalog_candidates_tsv() {
+	jq -r '.servers[] | [
+		.hostname,
+		.station,
+		.public_key,
+		.country_code,
+		.city,
+		((.load // 0) | tostring)
+	] | @tsv' "$1" 2>/dev/null
+}
+
+nordvpn_easy_recommendation_candidates_tsv() {
+	jq -r '.[] | [
+		.hostname,
+		.station,
+		([.technologies[]?.metadata[]? | select(.name=="public_key").value][0]),
+		(.locations[0].country.code // ""),
+		(.locations[0].country.city.name // ""),
+		((.load // 0) | tostring)
+	] | @tsv' "$1" 2>/dev/null
+}
+
+nordvpn_easy_emit_server_catalog_json() {
+	local catalog_file="$1"
+	local ts_file="$2"
+	local cache_ttl="${3:-86400}"
+	local cached_at=''
+
+	cached_at="$(cat "$ts_file" 2>/dev/null || true)"
+
+	jq -ce \
+		--arg cached_at "$cached_at" \
+		--arg cache_ttl "$cache_ttl" '
+			. + {
+				cached_at: ($cached_at | tonumber? // null),
+				cache_ttl: ($cache_ttl | tonumber? // 86400)
+			}
+		' "$catalog_file"
+}

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh
@@ -53,7 +53,12 @@ nordvpn_easy_recommendation_candidates_tsv() {
 	jq -r '.[] | [
 		.hostname,
 		.station,
-		([.technologies[]?.metadata[]? | select(.name=="public_key").value][0]),
+		([.technologies[]?
+			| select(.identifier == "wireguard_udp")
+			| .metadata[]?
+			| select(.name == "public_key")
+			| (.value // "")
+		][0] // ""),
 		(.locations[0].country.code // ""),
 		(.locations[0].country.city.name // ""),
 		((.load // 0) | tostring)

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
@@ -2,7 +2,9 @@
 
 nordvpn_easy_log() {
 	[ -t 2 ] && printf '*** %s ***\n' "$*" >&2
-	command -v logger >/dev/null 2>&1 && logger -t 'nordvpn-easy' "$*" >/dev/null 2>&1 || true
+	if command -v logger >/dev/null 2>&1; then
+		logger -t 'nordvpn-easy' "$*" >/dev/null 2>&1 || true
+	fi
 	return 0
 }
 

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+nordvpn_easy_log() {
+	[ -t 2 ] && printf '*** %s ***\n' "$*" >&2
+	command -v logger >/dev/null 2>&1 && logger -t 'nordvpn-easy' "$*"
+}
+
+nordvpn_easy_curl_rc_meaning() {
+	case "$1" in
+		0)  printf 'ok' ;;
+		6)  printf 'could not resolve host (DNS failure)' ;;
+		7)  printf 'failed to connect to host' ;;
+		28) printf 'operation timed out' ;;
+		35) printf 'SSL/TLS handshake failed' ;;
+		52) printf 'empty reply from server' ;;
+		56) printf 'receive failure' ;;
+		*)  printf 'curl error %s' "$1" ;;
+	esac
+}
+
+nordvpn_easy_lock_contention_is_nonfatal() {
+	case "$ACTION" in
+		run|check|refresh_countries)
+			return 0
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+nordvpn_easy_require_commands() {
+	local cmd
+
+	nordvpn_easy_log 'Validating required system commands'
+	for cmd in awk curl ifdown ifup ip jq ping uci; do
+		command -v "$cmd" >/dev/null 2>&1 || {
+			nordvpn_easy_log "$cmd IS MISSING, PLEASE INSTALL"
+			return 1
+		}
+	done
+	nordvpn_easy_log 'Required system commands are available'
+}
+
+nordvpn_easy_server_selection_is_manual() {
+	[ "$SERVER_SELECTION_MODE" = 'manual' ]
+}
+
+nordvpn_easy_server_cache_is_enabled() {
+	[ "$SERVER_CACHE_ENABLED" = '1' ]
+}
+
+nordvpn_easy_current_server_station() {
+	uci -q get "network.${VPN_IF}server.nordvpn_station" 2>/dev/null || \
+	uci -q get "network.${VPN_IF}server.endpoint_host" 2>/dev/null
+}
+
+nordvpn_easy_set_server_preference_in_uci() {
+	uci set "nordvpn_easy.main.preferred_server_hostname"="$1"
+	uci set "nordvpn_easy.main.preferred_server_station"="$2"
+}
+
+nordvpn_easy_require_manual_server_preference() {
+	nordvpn_easy_server_selection_is_manual || return 0
+
+	[ -n "$VPN_COUNTRY" ] || {
+		nordvpn_easy_log 'ERROR: MANUAL SERVER SELECTION REQUIRES A VPN_COUNTRY'
+		return 1
+	}
+
+	[ -n "$PREFERRED_SERVER_HOSTNAME" ] || {
+		nordvpn_easy_log 'ERROR: MANUAL SERVER SELECTION REQUIRES A PREFERRED_SERVER_HOSTNAME'
+		return 1
+	}
+
+	[ -n "$PREFERRED_SERVER_STATION" ] || {
+		nordvpn_easy_log 'ERROR: MANUAL SERVER SELECTION REQUIRES A PREFERRED_SERVER_STATION'
+		return 1
+	}
+}
+
+nordvpn_easy_server_cache_ttl_value() {
+	case "$SERVER_CACHE_TTL" in
+		''|*[!0-9]*)
+			printf '%s\n' '86400'
+			;;
+		*)
+			printf '%s\n' "$SERVER_CACHE_TTL"
+			;;
+	esac
+}
+
+nordvpn_easy_release_lock() {
+	[ "$LOCK_ACQUIRED" -eq 1 ] || return 0
+	rm -rf "$LOCK_DIR"
+	LOCK_ACQUIRED=0
+	nordvpn_easy_log "Released execution lock at $LOCK_DIR"
+}
+
+nordvpn_easy_acquire_lock() {
+	local lock_pid_file="${LOCK_DIR}/pid"
+	local lock_action_file="${LOCK_DIR}/action"
+	local lock_pid=''
+
+	if mkdir "$LOCK_DIR" 2>/dev/null; then
+		printf '%s\n' "$$" > "$lock_pid_file"
+		printf '%s\n' "$ACTION" > "$lock_action_file"
+		LOCK_ACQUIRED=1
+		trap 'nordvpn_easy_release_lock' EXIT HUP INT TERM
+		nordvpn_easy_log "Acquired execution lock at $LOCK_DIR"
+		return 0
+	fi
+
+	if [ -f "$lock_pid_file" ]; then
+		lock_pid="$(cat "$lock_pid_file" 2>/dev/null)"
+		if [ -n "$lock_pid" ] && kill -0 "$lock_pid" 2>/dev/null; then
+			nordvpn_easy_log "Execution lock is already held by PID $lock_pid"
+			return 2
+		fi
+	fi
+
+	nordvpn_easy_log "Recovering stale execution lock at $LOCK_DIR"
+	rm -rf "$LOCK_DIR" 2>/dev/null || return 1
+
+	mkdir "$LOCK_DIR" 2>/dev/null || return 1
+	printf '%s\n' "$$" > "$lock_pid_file"
+	printf '%s\n' "$ACTION" > "$lock_action_file"
+	LOCK_ACQUIRED=1
+	trap 'nordvpn_easy_release_lock' EXIT HUP INT TERM
+	nordvpn_easy_log "Recovered and acquired execution lock at $LOCK_DIR"
+}

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
@@ -2,7 +2,8 @@
 
 nordvpn_easy_log() {
 	[ -t 2 ] && printf '*** %s ***\n' "$*" >&2
-	command -v logger >/dev/null 2>&1 && logger -t 'nordvpn-easy' "$*"
+	command -v logger >/dev/null 2>&1 && logger -t 'nordvpn-easy' "$*" >/dev/null 2>&1 || true
+	return 0
 }
 
 nordvpn_easy_curl_rc_meaning() {
@@ -103,8 +104,11 @@ nordvpn_easy_acquire_lock() {
 	local lock_pid=''
 
 	if mkdir "$LOCK_DIR" 2>/dev/null; then
-		printf '%s\n' "$$" > "$lock_pid_file"
-		printf '%s\n' "$ACTION" > "$lock_action_file"
+		if ! printf '%s\n' "$$" > "$lock_pid_file" || ! printf '%s\n' "$ACTION" > "$lock_action_file"; then
+			rm -rf "$LOCK_DIR" 2>/dev/null
+			nordvpn_easy_log "ERROR: COULD NOT WRITE EXECUTION LOCK METADATA INTO $LOCK_DIR"
+			return 1
+		fi
 		LOCK_ACQUIRED=1
 		trap 'nordvpn_easy_release_lock' EXIT HUP INT TERM
 		nordvpn_easy_log "Acquired execution lock at $LOCK_DIR"
@@ -123,8 +127,11 @@ nordvpn_easy_acquire_lock() {
 	rm -rf "$LOCK_DIR" 2>/dev/null || return 1
 
 	mkdir "$LOCK_DIR" 2>/dev/null || return 1
-	printf '%s\n' "$$" > "$lock_pid_file"
-	printf '%s\n' "$ACTION" > "$lock_action_file"
+	if ! printf '%s\n' "$$" > "$lock_pid_file" || ! printf '%s\n' "$ACTION" > "$lock_action_file"; then
+		rm -rf "$LOCK_DIR" 2>/dev/null
+		nordvpn_easy_log "ERROR: COULD NOT WRITE EXECUTION LOCK METADATA INTO $LOCK_DIR"
+		return 1
+	fi
 	LOCK_ACQUIRED=1
 	trap 'nordvpn_easy_release_lock' EXIT HUP INT TERM
 	nordvpn_easy_log "Recovered and acquired execution lock at $LOCK_DIR"

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/runtime.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/runtime.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+
+nordvpn_easy_pluralize_time_unit() {
+	local value="$1"
+	local singular="$2"
+	local plural="$3"
+
+	if [ "$value" -eq 1 ]; then
+		printf '%s %s' "$value" "$singular"
+	else
+		printf '%s %s' "$value" "$plural"
+	fi
+}
+
+nordvpn_easy_format_relative_age() {
+	local total_seconds="$1"
+	local days hours minutes seconds output=''
+
+	case "$total_seconds" in
+		''|*[!0-9]*)
+			total_seconds=0
+			;;
+	esac
+
+	days=$((total_seconds / 86400))
+	hours=$(((total_seconds % 86400) / 3600))
+	minutes=$(((total_seconds % 3600) / 60))
+	seconds=$((total_seconds % 60))
+
+	if [ "$days" -gt 0 ]; then
+		output="$(nordvpn_easy_pluralize_time_unit "$days" 'day' 'days')"
+		[ "$hours" -gt 0 ] && output="$output, $(nordvpn_easy_pluralize_time_unit "$hours" 'hour' 'hours')"
+	elif [ "$hours" -gt 0 ]; then
+		output="$(nordvpn_easy_pluralize_time_unit "$hours" 'hour' 'hours')"
+		[ "$minutes" -gt 0 ] && output="$output, $(nordvpn_easy_pluralize_time_unit "$minutes" 'minute' 'minutes')"
+	elif [ "$minutes" -gt 0 ]; then
+		output="$(nordvpn_easy_pluralize_time_unit "$minutes" 'minute' 'minutes')"
+		[ "$seconds" -gt 0 ] && output="$output, $(nordvpn_easy_pluralize_time_unit "$seconds" 'second' 'seconds')"
+	else
+		output="$(nordvpn_easy_pluralize_time_unit "$seconds" 'second' 'seconds')"
+	fi
+
+	printf '%s ago\n' "$output"
+}
+
+nordvpn_easy_humanize_handshake_age() {
+	local epoch="$1"
+	local now diff
+
+	case "$epoch" in
+		''|*[!0-9]*)
+			printf '%s\n' 'Never'
+			return 0
+			;;
+	esac
+
+	[ "$epoch" -gt 0 ] || {
+		printf '%s\n' 'Never'
+		return 0
+	}
+
+	now="$(date +%s 2>/dev/null)"
+	case "$now" in
+		''|*[!0-9]*)
+			printf '%s\n' 'Unknown'
+			return 0
+			;;
+	esac
+
+	diff=$((now - epoch))
+	[ "$diff" -lt 0 ] && diff=0
+	nordvpn_easy_format_relative_age "$diff"
+}
+
+nordvpn_easy_handshake_epoch_indicates_connection() {
+	local epoch="$1"
+	local now diff
+
+	case "$epoch" in
+		''|*[!0-9]*)
+			return 1
+			;;
+	esac
+
+	[ "$epoch" -gt 0 ] || return 1
+	now="$(date +%s 2>/dev/null)"
+	case "$now" in
+		''|*[!0-9]*)
+			return 1
+			;;
+	esac
+
+	diff=$((now - epoch))
+	[ "$diff" -lt 0 ] && diff=0
+	[ "$diff" -le 7200 ]
+}
+
+nordvpn_easy_format_human_bytes() {
+	local bytes="$1"
+
+	case "$bytes" in
+		''|*[!0-9]*)
+			bytes=0
+			;;
+	esac
+
+	awk -v bytes="$bytes" '
+		BEGIN {
+			split("B KiB MiB GiB TiB PiB", units, " ")
+			size = bytes + 0
+			unit = 1
+			while (size >= 1024 && unit < 6) {
+				size /= 1024
+				unit++
+			}
+
+			if (unit == 1)
+				printf "%.0f %s\n", size, units[unit]
+			else
+				printf "%.2f %s\n", size, units[unit]
+		}
+	'
+}
+
+nordvpn_easy_parse_wg_dump_peer() {
+	printf '%s\n' "$1" | awk '
+		NR == 2 {
+			endpoint = ($3 != "" && $3 != "(none)") ? $3 : "N/A"
+			handshake = ($5 ~ /^[0-9]+$/) ? $5 : 0
+			rx = ($6 ~ /^[0-9]+$/) ? $6 : 0
+			tx = ($7 ~ /^[0-9]+$/) ? $7 : 0
+			printf "%s\t%s\t%s\t%s\n", endpoint, handshake, rx, tx
+			found = 1
+			exit
+		}
+		END {
+			if (!found)
+				printf "N/A\t0\t0\t0\n"
+		}
+	'
+}

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/schema.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/schema.sh
@@ -1,0 +1,187 @@
+#!/bin/sh
+
+NORDVPN_EASY_SCHEMA_VERSION="${NORDVPN_EASY_SCHEMA_VERSION:-2}"
+
+nordvpn_easy_shell_quote() {
+	printf "%s" "$1" | sed "s/'/'\\\\''/g"
+}
+
+nordvpn_easy_uci_options() {
+	cat <<'EOF'
+enabled
+nordvpn_token
+wan_if
+vpn_if
+vpn_country
+server_selection_mode
+preferred_server_hostname
+preferred_server_station
+server_cache_enabled
+server_cache_ttl
+vpn_port
+vpn_addr
+vpn_dns1
+vpn_dns2
+check_cron_schedule
+enable_hotplug
+failure_retry_delay
+server_rotate_threshold
+interface_restart_threshold
+max_interface_restarts
+interface_restart_delay
+post_restart_delay
+config_schema_version
+EOF
+}
+
+nordvpn_easy_runtime_options() {
+	cat <<'EOF'
+nordvpn_token
+wan_if
+vpn_if
+vpn_country
+server_selection_mode
+preferred_server_hostname
+preferred_server_station
+server_cache_enabled
+server_cache_ttl
+vpn_port
+vpn_addr
+vpn_dns1
+vpn_dns2
+check_cron_schedule
+enable_hotplug
+failure_retry_delay
+server_rotate_threshold
+interface_restart_threshold
+max_interface_restarts
+interface_restart_delay
+post_restart_delay
+EOF
+}
+
+nordvpn_easy_default() {
+	case "$1" in
+		enabled) printf '%s\n' '0' ;;
+		nordvpn_token) printf '%s\n' '' ;;
+		wan_if) printf '%s\n' 'wan' ;;
+		vpn_if) printf '%s\n' 'wg0' ;;
+		vpn_country) printf '%s\n' '' ;;
+		server_selection_mode) printf '%s\n' 'auto' ;;
+		preferred_server_hostname) printf '%s\n' '' ;;
+		preferred_server_station) printf '%s\n' '' ;;
+		server_cache_enabled) printf '%s\n' '1' ;;
+		server_cache_ttl) printf '%s\n' '86400' ;;
+		vpn_port) printf '%s\n' '51820' ;;
+		vpn_addr) printf '%s\n' '10.5.0.2/32' ;;
+		vpn_dns1) printf '%s\n' '103.86.99.99' ;;
+		vpn_dns2) printf '%s\n' '103.86.96.96' ;;
+		check_cron_schedule) printf '%s\n' '* * * * *' ;;
+		enable_hotplug) printf '%s\n' '1' ;;
+		failure_retry_delay) printf '%s\n' '6' ;;
+		server_rotate_threshold) printf '%s\n' '5' ;;
+		interface_restart_threshold) printf '%s\n' '10' ;;
+		max_interface_restarts) printf '%s\n' '3' ;;
+		interface_restart_delay) printf '%s\n' '10' ;;
+		post_restart_delay) printf '%s\n' '60' ;;
+		config_schema_version) printf '%s\n' "$NORDVPN_EASY_SCHEMA_VERSION" ;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+nordvpn_easy_is_bool_option() {
+	case "$1" in
+		enabled|server_cache_enabled|enable_hotplug)
+			return 0
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+nordvpn_easy_is_uint_option() {
+	case "$1" in
+		server_cache_ttl|vpn_port|failure_retry_delay|server_rotate_threshold|interface_restart_threshold|max_interface_restarts|interface_restart_delay|post_restart_delay)
+			return 0
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+nordvpn_easy_env_name() {
+	printf '%s\n' "$1" | tr '[:lower:]' '[:upper:]'
+}
+
+nordvpn_easy_normalize_bool() {
+	case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+		1|true|yes|on)
+			printf '%s\n' '1'
+			;;
+		*)
+			printf '%s\n' '0'
+			;;
+	esac
+}
+
+nordvpn_easy_normalize_value() {
+	local option="$1"
+	local value="$2"
+	local default_value=''
+
+	default_value="$(nordvpn_easy_default "$option" 2>/dev/null || printf '%s' '')"
+
+	if nordvpn_easy_is_bool_option "$option"; then
+		nordvpn_easy_normalize_bool "$value"
+		return 0
+	fi
+
+	if nordvpn_easy_is_uint_option "$option"; then
+		case "$value" in
+			''|*[!0-9]*)
+				printf '%s\n' "$default_value"
+				;;
+			*)
+				printf '%s\n' "$value"
+				;;
+		esac
+		return 0
+	fi
+
+	case "$option" in
+		server_selection_mode)
+			case "$value" in
+				manual)
+					printf '%s\n' 'manual'
+					;;
+				*)
+					printf '%s\n' 'auto'
+					;;
+			esac
+			;;
+		config_schema_version)
+			printf '%s\n' "$NORDVPN_EASY_SCHEMA_VERSION"
+			;;
+		*)
+			printf '%s\n' "$value"
+			;;
+	esac
+}
+
+nordvpn_easy_apply_env_defaults() {
+	local option env_name default_value current
+
+	for option in $(nordvpn_easy_runtime_options); do
+		env_name="$(nordvpn_easy_env_name "$option")"
+		default_value="$(nordvpn_easy_default "$option" 2>/dev/null || printf '%s' '')"
+		eval "current=\${$env_name-__NORDVPN_EASY_UNSET__}"
+
+		if [ "$current" = '__NORDVPN_EASY_UNSET__' ] || [ -z "$current" ]; then
+			eval "$env_name='$(nordvpn_easy_shell_quote "$default_value")'"
+		fi
+	done
+}

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/service-config.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/service-config.sh
@@ -28,11 +28,7 @@ nordvpn_easy_migrate_service_config() {
 		normalized_value="$(nordvpn_easy_normalize_value "$option" "$old_value")"
 
 		if ! uci -q get "${section_ref}.${option}" >/dev/null 2>&1 || [ "$normalized_value" != "$old_value" ]; then
-			if [ -z "$normalized_value" ] && [ -z "$default_value" ]; then
-				uci set "${section_ref}.${option}="
-			else
-				uci set "${section_ref}.${option}=$normalized_value"
-			fi
+			uci set "${section_ref}.${option}=$normalized_value"
 			changed=1
 		fi
 	done

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/service-config.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/service-config.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+nordvpn_easy_migrate_service_config() {
+	local uci_config="$1"
+	local uci_section="$2"
+	local section_ref="${uci_config}.${uci_section}"
+	local changed=0
+	local option old_value default_value normalized_value
+
+	if ! uci -q get "$section_ref" >/dev/null 2>&1; then
+		uci set "${section_ref}=nordvpn_easy"
+		changed=1
+	fi
+
+	if uci -q get "${section_ref}.nordvpn_basic_token" >/dev/null 2>&1; then
+		uci -q delete "${section_ref}.nordvpn_basic_token"
+		changed=1
+	fi
+
+	for option in $(nordvpn_easy_uci_options); do
+		default_value="$(nordvpn_easy_default "$option" 2>/dev/null || printf '%s' '')"
+		if uci -q get "${section_ref}.${option}" >/dev/null 2>&1; then
+			old_value="$(uci -q get "${section_ref}.${option}" 2>/dev/null)"
+		else
+			old_value=''
+		fi
+
+		normalized_value="$(nordvpn_easy_normalize_value "$option" "$old_value")"
+
+		if ! uci -q get "${section_ref}.${option}" >/dev/null 2>&1 || [ "$normalized_value" != "$old_value" ]; then
+			if [ -z "$normalized_value" ] && [ -z "$default_value" ]; then
+				uci set "${section_ref}.${option}="
+			else
+				uci set "${section_ref}.${option}=$normalized_value"
+			fi
+			changed=1
+		fi
+	done
+
+	if [ "$changed" -eq 1 ]; then
+		uci -q commit "$uci_config" || {
+			printf '%s\n' "nordvpn-easy: failed to commit migrated config" >&2
+			return 1
+		}
+	fi
+}

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/wireguard.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/wireguard.sh
@@ -1,0 +1,274 @@
+#!/bin/sh
+
+nordvpn_easy_vpn_is_configured() {
+	[ "$(uci -q get "network.${VPN_IF}.proto" 2>/dev/null)" = 'wireguard' ]
+}
+
+nordvpn_easy_vpn_link_is_present() {
+	ip link show dev "$VPN_IF" >/dev/null 2>&1
+}
+
+nordvpn_easy_log_vpn_interface_state() {
+	STATE_CONTEXT="$1"
+	VPN_PROTO=$(uci -q get "network.${VPN_IF}.proto" 2>/dev/null)
+	VPN_DISABLED=$(uci -q get "network.${VPN_IF}.disabled" 2>/dev/null)
+	VPN_ENDPOINT=$(uci -q get "network.${VPN_IF}server.endpoint_host" 2>/dev/null)
+	VPN_LINK_PRESENT='no'
+
+	ip link show dev "$VPN_IF" >/dev/null 2>&1 && VPN_LINK_PRESENT='yes'
+
+	log "Interface state [$STATE_CONTEXT]: proto=${VPN_PROTO:-absent}, disabled=${VPN_DISABLED:-0}, link_present=$VPN_LINK_PRESENT, endpoint=${VPN_ENDPOINT:-none}"
+}
+
+nordvpn_easy_recover_missing_vpn_interface() {
+	log "VPN interface $VPN_IF is still not present after ${VPN_INTERFACE_PRESENT_DELAY}s - starting recovery sequence"
+	log_vpn_interface_state 'missing-interface-start'
+
+	log "Recovery step 1/3: cycling interface $VPN_IF with ifdown/ifup"
+	ifdown "$VPN_IF" >/dev/null 2>&1 || true
+	ifup "$VPN_IF" >/dev/null 2>&1 || true
+	sleep "$VPN_INTERFACE_PRESENT_DELAY"
+
+	if vpn_link_is_present; then
+		log "Recovery step 1/3 succeeded: interface $VPN_IF is present again"
+		log_vpn_interface_state 'missing-interface-after-ifup'
+		return 0
+	fi
+
+	log "Recovery step 2/3: reloading network service because $VPN_IF is still not present"
+	/etc/init.d/network reload || {
+		log 'ERROR: NETWORK RELOAD FAILED DURING MISSING INTERFACE RECOVERY'
+		return 1
+	}
+	sleep "$VPN_INTERFACE_PRESENT_DELAY"
+
+	if vpn_link_is_present; then
+		log "Recovery step 2/3 succeeded: interface $VPN_IF is present again"
+		log_vpn_interface_state 'missing-interface-after-reload'
+		return 0
+	fi
+
+	log "Recovery step 3/3: restarting network service because $VPN_IF is still not present"
+	/etc/init.d/network restart || {
+		log 'ERROR: NETWORK RESTART FAILED DURING MISSING INTERFACE RECOVERY'
+		return 1
+	}
+	sleep "$VPN_INTERFACE_PRESENT_DELAY"
+
+	if vpn_link_is_present; then
+		log "Recovery step 3/3 succeeded: interface $VPN_IF is present again"
+		log_vpn_interface_state 'missing-interface-after-restart'
+		return 0
+	fi
+
+	log "ERROR: VPN interface $VPN_IF is still not present after the full recovery sequence"
+	log_vpn_interface_state 'missing-interface-final'
+	return 1
+}
+
+nordvpn_easy_ensure_vpn_interface_present() {
+	if vpn_link_is_present; then
+		return 0
+	fi
+
+	log "VPN interface $VPN_IF is not present, waiting ${VPN_INTERFACE_PRESENT_DELAY}s before recovery"
+	log_vpn_interface_state 'missing-interface-before-wait'
+	sleep "$VPN_INTERFACE_PRESENT_DELAY"
+
+	if vpn_link_is_present; then
+		log "VPN interface $VPN_IF became present during the wait window"
+		log_vpn_interface_state 'missing-interface-after-wait'
+		return 0
+	fi
+
+	recover_missing_vpn_interface
+}
+
+nordvpn_easy_ensure_vpn_interface_enabled() {
+	[ "$(uci -q get "network.${VPN_IF}.disabled" 2>/dev/null)" = '1' ] || return 0
+
+	log "Re-enabling disabled VPN interface $VPN_IF"
+	log_vpn_interface_state 'before-enable'
+	uci -q delete "network.${VPN_IF}.disabled"
+	uci commit network || {
+		log "ERROR: COULD NOT COMMIT NETWORK CONFIGURATION WHILE ENABLING $VPN_IF"
+		return 1
+	}
+
+	/etc/init.d/network reload || {
+		log "ERROR: NETWORK RELOAD FAILED WHILE ENABLING $VPN_IF"
+		return 1
+	}
+
+	ifup "$VPN_IF" || {
+		log "ERROR: IFUP FAILED WHILE ENABLING $VPN_IF"
+		return 1
+	}
+
+	log "VPN interface $VPN_IF has been re-enabled"
+	log_vpn_interface_state 'after-enable'
+}
+
+nordvpn_easy_ping_interface() {
+	[ -n "$1" ] || return 1
+	ping -q -c 1 -W 5 "$(pick_ping_ip)" -I "$1" >/dev/null 2>&1
+}
+
+nordvpn_easy_resolve_wan_device() {
+	WAN_DEVICE=''
+
+	if command -v ubus >/dev/null 2>&1; then
+		WAN_DEVICE=$(ubus call "network.interface.${WAN_IF}" status 2>/dev/null | jq -er '.l3_device // .device // empty' 2>/dev/null)
+		[ -n "$WAN_DEVICE" ] && return 0
+	fi
+
+	WAN_DEVICE=$(uci -q get "network.${WAN_IF}.device" 2>/dev/null)
+	[ -n "$WAN_DEVICE" ] && return 0
+
+	WAN_DEVICE=$(uci -q get "network.${WAN_IF}.ifname" 2>/dev/null)
+	[ -n "$WAN_DEVICE" ] && return 0
+
+	if ip link show dev "$WAN_IF" >/dev/null 2>&1; then
+		WAN_DEVICE="$WAN_IF"
+		return 0
+	fi
+
+	log "ERROR: COULD NOT RESOLVE DEVICE FOR $WAN_IF"
+	return 1
+}
+
+nordvpn_easy_ping_wan() {
+	resolve_wan_device || return 1
+	ping_interface "$WAN_DEVICE"
+}
+
+nordvpn_easy_find_firewall_zone_section() {
+	TARGET_NETWORK="$1"
+
+	for FIREWALL_SECTION in $(uci show firewall | awk -F= '$2=="zone"{ print $1 }'); do
+		ZONE_NETWORKS=$(uci -q get "${FIREWALL_SECTION}.network" 2>/dev/null)
+
+		for ZONE_NETWORK in $ZONE_NETWORKS; do
+			[ "$ZONE_NETWORK" = "$TARGET_NETWORK" ] && {
+				printf '%s\n' "$FIREWALL_SECTION"
+				return 0
+			}
+		done
+	done
+
+	return 1
+}
+
+nordvpn_easy_ensure_vpn_in_wan_zone() {
+	WAN_ZONE=$(find_firewall_zone_section "$WAN_IF") || {
+		log "ERROR: FIREWALL ZONE FOR $WAN_IF NOT FOUND"
+		return 1
+	}
+
+	FIREWALL_CHANGED=0
+
+	for FIREWALL_SECTION in $(uci show firewall | awk -F= '$2=="zone"{ print $1 }'); do
+		[ "$FIREWALL_SECTION" = "$WAN_ZONE" ] && continue
+
+		ZONE_NETWORKS=$(uci -q get "${FIREWALL_SECTION}.network" 2>/dev/null)
+		for ZONE_NETWORK in $ZONE_NETWORKS; do
+			[ "$ZONE_NETWORK" = "$VPN_IF" ] || continue
+			uci -q del_list "${FIREWALL_SECTION}.network"="$VPN_IF"
+			FIREWALL_CHANGED=1
+			break
+		done
+	done
+
+	ZONE_HAS_VPN=0
+	ZONE_NETWORKS=$(uci -q get "${WAN_ZONE}.network" 2>/dev/null)
+
+	for ZONE_NETWORK in $ZONE_NETWORKS; do
+		[ "$ZONE_NETWORK" = "$VPN_IF" ] && {
+			ZONE_HAS_VPN=1
+			break
+		}
+	done
+
+	if [ "$ZONE_HAS_VPN" -ne 1 ]; then
+		uci add_list "${WAN_ZONE}.network"="$VPN_IF"
+		FIREWALL_CHANGED=1
+	fi
+
+	if [ "$FIREWALL_CHANGED" -ne 1 ]; then
+		log "Firewall zone for $WAN_IF already contains $VPN_IF"
+		return 0
+	fi
+
+	uci commit firewall || {
+		log 'ERROR: COULD NOT COMMIT FIREWALL CONFIGURATION'
+		return 1
+	}
+
+	/etc/init.d/firewall restart || {
+		log 'ERROR: FIREWALL RESTART FAILED'
+		return 1
+	}
+
+	log "Firewall updated so zone for $WAN_IF includes $VPN_IF"
+}
+
+nordvpn_easy_set_vpn_server_in_uci() {
+	[ -n "$2" ] || {
+		log 'ERROR: VPN SERVER IP IS EMPTY'
+		return 1
+	}
+	[ -n "$3" ] || {
+		log "ERROR: VPN PUBLIC KEY IS EMPTY FOR $1"
+		return 1
+	}
+
+	uci set "network.${VPN_IF}server.description"="$1"
+	uci set "network.${VPN_IF}server.endpoint_host"="$2"
+	uci set "network.${VPN_IF}server.public_key"="$3"
+	uci set "network.${VPN_IF}server.nordvpn_hostname"="$1"
+	uci set "network.${VPN_IF}server.nordvpn_station"="$2"
+	uci set "network.${VPN_IF}server.nordvpn_country_code"="${4:-}"
+	uci set "network.${VPN_IF}server.nordvpn_city"="${5:-}"
+	uci set "network.${VPN_IF}server.nordvpn_load"="${6:-}"
+	log "Prepared VPN peer update for server $1 ($2)"
+}
+
+nordvpn_easy_current_server_matches_recommendations() {
+	CURRENT_SERVER=$(current_server_station)
+
+	[ -n "$CURRENT_SERVER" ] || return 1
+
+	jq -e --arg current "$CURRENT_SERVER" '
+		[ .[] | select(.station == $current) ] | length > 0
+	' "$SERVER_LIST_FILE" >/dev/null 2>&1
+}
+
+nordvpn_easy_apply_server_change_runtime() {
+	if [ "$1" = 'reload' ]; then
+		log "Cycling VPN interface $VPN_IF to apply the new peer configuration"
+		ifdown "$VPN_IF" >/dev/null 2>&1 || true
+		sleep "$INTERFACE_RESTART_DELAY"
+		ifup "$VPN_IF" || {
+			log "ERROR: IFUP FAILED AFTER CHANGING VPN SERVER ON $VPN_IF"
+			return 1
+		}
+		log "Waiting ${POST_RESTART_DELAY}s after cycling $VPN_IF before validating VPN connectivity"
+	else
+		/etc/init.d/network restart || {
+			log 'ERROR: NETWORK RESTART FAILED'
+			return 1
+		}
+		log "Waiting ${POST_RESTART_DELAY}s after network restart before validating VPN connectivity"
+	fi
+
+	sleep "$POST_RESTART_DELAY"
+
+	if ping_interface "$VPN_IF"; then
+		log 'VPN connection restored'
+		verify_public_country_selection
+		return 0
+	fi
+
+	log 'VPN connection is not OK, trying another server...'
+	return 1
+}

--- a/scripts/check-nordvpn-easy.sh
+++ b/scripts/check-nordvpn-easy.sh
@@ -2,7 +2,8 @@
 
 set -eu
 
-ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)"
+SHELLCHECK_EXCLUDES='SC1091,SC2034,SC2119,SC2120,SC2154,SC3043'
 
 JS_FILES="
 $ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
@@ -53,7 +54,7 @@ sh "$ROOT_DIR/tests/nordvpn-easy/test-actions.sh"
 
 if command -v shellcheck >/dev/null 2>&1; then
 	printf '%s\n' 'Running shellcheck'
-	shellcheck $SH_FILES
+	shellcheck -e "$SHELLCHECK_EXCLUDES" $SH_FILES
 else
 	printf '%s\n' 'shellcheck not found; skipping'
 fi

--- a/scripts/check-nordvpn-easy.sh
+++ b/scripts/check-nordvpn-easy.sh
@@ -1,46 +1,46 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 ROOT_DIR="$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)"
 SHELLCHECK_EXCLUDES='SC1091,SC2034,SC2119,SC2120,SC2154,SC3043'
 
-JS_FILES="
-$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
-$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-data.js
-$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js
-$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-ui.js
-$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-state.js
-$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
-$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/advanced.js
-$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/diagnostics.js
-"
+JS_FILES=(
+	"$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js"
+	"$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-data.js"
+	"$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js"
+	"$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-ui.js"
+	"$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-state.js"
+	"$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js"
+	"$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/advanced.js"
+	"$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/diagnostics.js"
+)
 
-SH_FILES="
-$ROOT_DIR/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
-$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
-$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/schema.sh
-$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
-$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh
-$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/runtime.sh
-$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/wireguard.sh
-$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
-$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/service-config.sh
-$ROOT_DIR/tests/nordvpn-easy/test-schema.sh
-$ROOT_DIR/tests/nordvpn-easy/test-catalog-fixtures.sh
-$ROOT_DIR/tests/nordvpn-easy/test-common-lock.sh
-$ROOT_DIR/tests/nordvpn-easy/test-runtime.sh
-$ROOT_DIR/tests/nordvpn-easy/test-service-config.sh
-$ROOT_DIR/tests/nordvpn-easy/test-actions.sh
-"
+SH_FILES=(
+	"$ROOT_DIR/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy"
+	"$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh"
+	"$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/schema.sh"
+	"$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh"
+	"$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh"
+	"$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/runtime.sh"
+	"$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/wireguard.sh"
+	"$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh"
+	"$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/service-config.sh"
+	"$ROOT_DIR/tests/nordvpn-easy/test-schema.sh"
+	"$ROOT_DIR/tests/nordvpn-easy/test-catalog-fixtures.sh"
+	"$ROOT_DIR/tests/nordvpn-easy/test-common-lock.sh"
+	"$ROOT_DIR/tests/nordvpn-easy/test-runtime.sh"
+	"$ROOT_DIR/tests/nordvpn-easy/test-service-config.sh"
+	"$ROOT_DIR/tests/nordvpn-easy/test-actions.sh"
+)
 
 printf '%s\n' 'Checking LuCI JavaScript syntax'
-for file in $JS_FILES; do
+for file in "${JS_FILES[@]}"; do
 	node --check "$file"
 done
 
 printf '%s\n' 'Checking shell syntax'
-for file in $SH_FILES; do
+for file in "${SH_FILES[@]}"; do
 	sh -n "$file"
 done
 
@@ -54,7 +54,7 @@ sh "$ROOT_DIR/tests/nordvpn-easy/test-actions.sh"
 
 if command -v shellcheck >/dev/null 2>&1; then
 	printf '%s\n' 'Running shellcheck'
-	shellcheck -e "$SHELLCHECK_EXCLUDES" $SH_FILES
+	shellcheck -e "$SHELLCHECK_EXCLUDES" "${SH_FILES[@]}"
 else
 	printf '%s\n' 'shellcheck not found; skipping'
 fi

--- a/scripts/check-nordvpn-easy.sh
+++ b/scripts/check-nordvpn-easy.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+
+JS_FILES="
+$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
+$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-data.js
+$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js
+$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-ui.js
+$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-state.js
+$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/advanced.js
+$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/diagnostics.js
+"
+
+SH_FILES="
+$ROOT_DIR/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/schema.sh
+$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
+$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh
+$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/runtime.sh
+$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/wireguard.sh
+$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
+$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/service-config.sh
+$ROOT_DIR/tests/nordvpn-easy/test-schema.sh
+$ROOT_DIR/tests/nordvpn-easy/test-catalog-fixtures.sh
+$ROOT_DIR/tests/nordvpn-easy/test-common-lock.sh
+$ROOT_DIR/tests/nordvpn-easy/test-runtime.sh
+$ROOT_DIR/tests/nordvpn-easy/test-service-config.sh
+$ROOT_DIR/tests/nordvpn-easy/test-actions.sh
+"
+
+printf '%s\n' 'Checking LuCI JavaScript syntax'
+for file in $JS_FILES; do
+	node --check "$file"
+done
+
+printf '%s\n' 'Checking shell syntax'
+for file in $SH_FILES; do
+	sh -n "$file"
+done
+
+printf '%s\n' 'Running fixture tests'
+sh "$ROOT_DIR/tests/nordvpn-easy/test-schema.sh"
+sh "$ROOT_DIR/tests/nordvpn-easy/test-catalog-fixtures.sh"
+sh "$ROOT_DIR/tests/nordvpn-easy/test-common-lock.sh"
+sh "$ROOT_DIR/tests/nordvpn-easy/test-runtime.sh"
+sh "$ROOT_DIR/tests/nordvpn-easy/test-service-config.sh"
+sh "$ROOT_DIR/tests/nordvpn-easy/test-actions.sh"
+
+if command -v shellcheck >/dev/null 2>&1; then
+	printf '%s\n' 'Running shellcheck'
+	shellcheck $SH_FILES
+else
+	printf '%s\n' 'shellcheck not found; skipping'
+fi
+
+printf '%s\n' 'All NordVPN Easy checks passed'

--- a/tests/nordvpn-easy/fixtures/nordvpn-api-servers.json
+++ b/tests/nordvpn-easy/fixtures/nordvpn-api-servers.json
@@ -1,0 +1,109 @@
+[
+  {
+    "hostname": "it12.nordvpn.com",
+    "station": "it123",
+    "load": 12,
+    "status": "online",
+    "locations": [
+      {
+        "country": {
+          "code": "IT",
+          "name": "Italy",
+          "city": {
+            "name": "Milan"
+          }
+        }
+      }
+    ],
+    "technologies": [
+      {
+        "identifier": "wireguard_udp",
+        "metadata": [
+          {
+            "name": "public_key",
+            "value": "PUBKEY-123"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "hostname": "it45.nordvpn.com",
+    "station": "it456",
+    "load": 45,
+    "status": "online",
+    "locations": [
+      {
+        "country": {
+          "code": "IT",
+          "name": "Italy",
+          "city": {
+            "name": "Rome"
+          }
+        }
+      }
+    ],
+    "technologies": [
+      {
+        "identifier": "wireguard_udp",
+        "metadata": [
+          {
+            "name": "public_key",
+            "value": "PUBKEY-456"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "hostname": "it99.nordvpn.com",
+    "station": "it999",
+    "load": 2,
+    "status": "offline",
+    "locations": [
+      {
+        "country": {
+          "code": "IT",
+          "name": "Italy",
+          "city": {
+            "name": "Turin"
+          }
+        }
+      }
+    ],
+    "technologies": [
+      {
+        "identifier": "wireguard_udp",
+        "metadata": [
+          {
+            "name": "public_key",
+            "value": "PUBKEY-999"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "hostname": "it-no-key.nordvpn.com",
+    "station": "it000",
+    "load": 1,
+    "status": "online",
+    "locations": [
+      {
+        "country": {
+          "code": "IT",
+          "name": "Italy",
+          "city": {
+            "name": "Bologna"
+          }
+        }
+      }
+    ],
+    "technologies": [
+      {
+        "identifier": "wireguard_udp",
+        "metadata": []
+      }
+    ]
+  }
+]

--- a/tests/nordvpn-easy/test-actions.sh
+++ b/tests/nordvpn-easy/test-actions.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+CATALOG_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh"
+ACTIONS_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh"
+FIXTURE="$ROOT_DIR/tests/nordvpn-easy/fixtures/nordvpn-api-servers.json"
+TMP_DIR="$(mktemp -d)"
+SERVER_LIST_FILE="$TMP_DIR/recommendations.json"
+SERVER_CATALOG_FILE="$TMP_DIR/catalog.json"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+# shellcheck disable=SC1090
+. "$CATALOG_LIB"
+# shellcheck disable=SC1090
+. "$ACTIONS_LIB"
+
+assert_eq() {
+	expected="$1"
+	actual="$2"
+	label="$3"
+
+	if [ "$expected" != "$actual" ]; then
+		printf '%s\n' "FAIL: $label" >&2
+		printf '%s\n' "expected: $expected" >&2
+		printf '%s\n' "actual:   $actual" >&2
+		exit 1
+	fi
+}
+
+jq '. + [{
+	"hostname": "it77.nordvpn.com",
+	"station": "it777",
+	"load": 77,
+	"status": "online",
+	"locations": [{
+		"country": {
+			"code": "IT",
+			"name": "Italy",
+			"city": { "name": "Naples" }
+		}
+	}],
+	"technologies": [{
+		"identifier": "wireguard_udp",
+		"metadata": [{ "name": "public_key", "value": "PUBKEY-777" }]
+	}]
+}]' "$FIXTURE" > "$SERVER_LIST_FILE"
+
+nordvpn_easy_build_server_catalog_json 237 IT Italy < "$SERVER_LIST_FILE" > "$SERVER_CATALOG_FILE"
+
+VPN_COUNTRY='IT'
+SERVER_RECOMMENDATIONS_URL_BASE='https://example.invalid/recommendations'
+CURRENT_SERVER_VALUE='it0'
+COMMIT_NETWORK_COUNT=0
+COMMIT_PREF_COUNT=0
+APPLY_COUNT=0
+APPLY_FAIL_UNTIL=0
+COMMIT_PREF_FAIL_UNTIL=0
+LAST_SET_SERVER=''
+SAVED_PREFERENCE=''
+PREFERRED_SERVER_HOSTNAME='it12.nordvpn.com'
+PREFERRED_SERVER_STATION='it123'
+
+log() { :; }
+require_manual_server_preference() { return 0; }
+fetch_server_catalog() { return 0; }
+current_server_station() { printf '%s\n' "$CURRENT_SERVER_VALUE"; }
+set_vpn_server_in_uci() { LAST_SET_SERVER="$1|$2"; return 0; }
+set_server_preference_in_uci() { SAVED_PREFERENCE="$1|$2"; }
+verify_public_country_selection() { :; }
+ping_interface() { return 0; }
+get_servers_list() { return 0; }
+server_selection_is_manual() { [ "${SERVER_SELECTION_MODE:-auto}" = 'manual' ]; }
+vpn_is_configured() { return 0; }
+preferred_server_matches_current() { return 1; }
+apply_preferred_server_from_catalog() { return 0; }
+
+uci() {
+	if [ "$1" = 'commit' ] && [ "$2" = 'network' ]; then
+		COMMIT_NETWORK_COUNT=$((COMMIT_NETWORK_COUNT + 1))
+		return 0
+	fi
+
+	if [ "$1" = 'commit' ] && [ "$2" = 'nordvpn_easy' ]; then
+		COMMIT_PREF_COUNT=$((COMMIT_PREF_COUNT + 1))
+		if [ "$COMMIT_PREF_COUNT" -le "$COMMIT_PREF_FAIL_UNTIL" ]; then
+			return 1
+		fi
+		return 0
+	fi
+
+	return 0
+}
+
+apply_server_change_runtime() {
+	APPLY_COUNT=$((APPLY_COUNT + 1))
+	if [ "$APPLY_COUNT" -le "$APPLY_FAIL_UNTIL" ]; then
+		return 1
+	fi
+	return 0
+}
+
+APPLY_FAIL_UNTIL=1
+APPLY_COUNT=0
+COMMIT_NETWORK_COUNT=0
+LAST_SET_SERVER=''
+
+nordvpn_easy_change_vpn_server reload
+
+assert_eq '2' "$APPLY_COUNT" 'recommended rotation retries next candidate after apply failure'
+assert_eq '2' "$COMMIT_NETWORK_COUNT" 'recommended rotation commits each tried candidate'
+assert_eq 'it45.nordvpn.com|it456' "$LAST_SET_SERVER" 'recommended rotation lands on second candidate'
+[ ! -f "/tmp/nordvpn.candidates.$$" ] || {
+	printf '%s\n' 'FAIL: recommended candidate file was not removed' >&2
+	exit 1
+}
+
+APPLY_FAIL_UNTIL=0
+APPLY_COUNT=0
+COMMIT_NETWORK_COUNT=0
+COMMIT_PREF_COUNT=0
+COMMIT_PREF_FAIL_UNTIL=1
+LAST_SET_SERVER=''
+SAVED_PREFERENCE=''
+
+nordvpn_easy_change_manual_server reload
+
+assert_eq '2' "$COMMIT_PREF_COUNT" 'manual rotation retries after preference commit failure'
+assert_eq 'it45.nordvpn.com|it456' "$SAVED_PREFERENCE" 'manual rotation persists the next successful preference'
+assert_eq 'it45.nordvpn.com' "$PREFERRED_SERVER_HOSTNAME" 'manual hostname updated in environment'
+assert_eq 'it456' "$PREFERRED_SERVER_STATION" 'manual station updated in environment'
+[ ! -f "/tmp/nordvpn-manual.candidates.$$" ] || {
+	printf '%s\n' 'FAIL: manual candidate file was not removed' >&2
+	exit 1
+}
+
+printf '%s\n' 'test-actions.sh: ok'

--- a/tests/nordvpn-easy/test-actions.sh
+++ b/tests/nordvpn-easy/test-actions.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)"
 CATALOG_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh"
 ACTIONS_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh"
 FIXTURE="$ROOT_DIR/tests/nordvpn-easy/fixtures/nordvpn-api-servers.json"

--- a/tests/nordvpn-easy/test-actions.sh
+++ b/tests/nordvpn-easy/test-actions.sh
@@ -9,6 +9,7 @@ FIXTURE="$ROOT_DIR/tests/nordvpn-easy/fixtures/nordvpn-api-servers.json"
 TMP_DIR="$(mktemp -d)"
 SERVER_LIST_FILE="$TMP_DIR/recommendations.json"
 SERVER_CATALOG_FILE="$TMP_DIR/catalog.json"
+FIRST_SERVER_LIST_FILE="$TMP_DIR/first-server.json"
 
 cleanup() {
 	rm -rf "$TMP_DIR"
@@ -63,6 +64,7 @@ APPLY_COUNT=0
 APPLY_FAIL_UNTIL=0
 COMMIT_PREF_FAIL_UNTIL=0
 LAST_SET_SERVER=''
+LAST_SET_PUBLIC_KEY=''
 SAVED_PREFERENCE=''
 PREFERRED_SERVER_HOSTNAME='it12.nordvpn.com'
 PREFERRED_SERVER_STATION='it123'
@@ -71,7 +73,7 @@ log() { :; }
 require_manual_server_preference() { return 0; }
 fetch_server_catalog() { return 0; }
 current_server_station() { printf '%s\n' "$CURRENT_SERVER_VALUE"; }
-set_vpn_server_in_uci() { LAST_SET_SERVER="$1|$2"; return 0; }
+set_vpn_server_in_uci() { LAST_SET_SERVER="$1|$2"; LAST_SET_PUBLIC_KEY="$3"; return 0; }
 set_server_preference_in_uci() { SAVED_PREFERENCE="$1|$2"; }
 verify_public_country_selection() { :; }
 ping_interface() { return 0; }
@@ -106,6 +108,28 @@ apply_server_change_runtime() {
 	return 0
 }
 
+jq '.[0].technologies = [
+	{
+		"identifier": "openvpn_udp",
+		"metadata": [{ "name": "public_key", "value": "WRONG-KEY" }]
+	},
+	{
+		"identifier": "wireguard_udp",
+		"metadata": [{ "name": "public_key", "value": "RIGHT-KEY" }]
+	}
+]' "$FIXTURE" > "$FIRST_SERVER_LIST_FILE"
+
+SERVER_LIST_FILE="$FIRST_SERVER_LIST_FILE"
+LAST_SET_SERVER=''
+LAST_SET_PUBLIC_KEY=''
+
+nordvpn_easy_set_first_server_from_list
+
+assert_eq 'it12.nordvpn.com|it123' "$LAST_SET_SERVER" 'first recommended server uses first list entry'
+assert_eq 'RIGHT-KEY' "$LAST_SET_PUBLIC_KEY" 'first recommended server uses WireGuard public key'
+
+SERVER_LIST_FILE="$TMP_DIR/recommendations.json"
+
 APPLY_FAIL_UNTIL=1
 APPLY_COUNT=0
 COMMIT_NETWORK_COUNT=0
@@ -128,13 +152,15 @@ COMMIT_PREF_COUNT=0
 COMMIT_PREF_FAIL_UNTIL=1
 LAST_SET_SERVER=''
 SAVED_PREFERENCE=''
+LAST_SET_PUBLIC_KEY=''
 
 nordvpn_easy_change_manual_server reload
 
-assert_eq '2' "$COMMIT_PREF_COUNT" 'manual rotation retries after preference commit failure'
-assert_eq 'it45.nordvpn.com|it456' "$SAVED_PREFERENCE" 'manual rotation persists the next successful preference'
-assert_eq 'it45.nordvpn.com' "$PREFERRED_SERVER_HOSTNAME" 'manual hostname updated in environment'
-assert_eq 'it456' "$PREFERRED_SERVER_STATION" 'manual station updated in environment'
+assert_eq '1' "$COMMIT_PREF_COUNT" 'manual rotation does not retry after preference commit failure once runtime apply succeeded'
+assert_eq '1' "$APPLY_COUNT" 'manual rotation keeps the first successful runtime apply'
+assert_eq 'it12.nordvpn.com|it123' "$SAVED_PREFERENCE" 'manual rotation keeps the applied server preference even when commit warns'
+assert_eq 'it12.nordvpn.com' "$PREFERRED_SERVER_HOSTNAME" 'manual hostname updated in environment'
+assert_eq 'it123' "$PREFERRED_SERVER_STATION" 'manual station updated in environment'
 [ ! -f "/tmp/nordvpn-manual.candidates.$$" ] || {
 	printf '%s\n' 'FAIL: manual candidate file was not removed' >&2
 	exit 1

--- a/tests/nordvpn-easy/test-actions.sh
+++ b/tests/nordvpn-easy/test-actions.sh
@@ -70,18 +70,24 @@ PREFERRED_SERVER_HOSTNAME='it12.nordvpn.com'
 PREFERRED_SERVER_STATION='it123'
 
 log() { :; }
-require_manual_server_preference() { return 0; }
 fetch_server_catalog() { return 0; }
-current_server_station() { printf '%s\n' "$CURRENT_SERVER_VALUE"; }
-set_vpn_server_in_uci() { LAST_SET_SERVER="$1|$2"; LAST_SET_PUBLIC_KEY="$3"; return 0; }
-set_server_preference_in_uci() { SAVED_PREFERENCE="$1|$2"; }
-verify_public_country_selection() { :; }
-ping_interface() { return 0; }
-get_servers_list() { return 0; }
-server_selection_is_manual() { [ "${SERVER_SELECTION_MODE:-auto}" = 'manual' ]; }
-vpn_is_configured() { return 0; }
-preferred_server_matches_current() { return 1; }
-apply_preferred_server_from_catalog() { return 0; }
+nordvpn_easy_require_manual_server_preference() { return 0; }
+nordvpn_easy_current_server_station() { printf '%s\n' "$CURRENT_SERVER_VALUE"; }
+nordvpn_easy_set_vpn_server_in_uci() { LAST_SET_SERVER="$1|$2"; LAST_SET_PUBLIC_KEY="$3"; return 0; }
+nordvpn_easy_set_server_preference_in_uci() { SAVED_PREFERENCE="$1|$2"; }
+nordvpn_easy_ping_interface() { return 0; }
+nordvpn_easy_get_servers_list() { return 0; }
+nordvpn_easy_server_selection_is_manual() { [ "${SERVER_SELECTION_MODE:-auto}" = 'manual' ]; }
+nordvpn_easy_vpn_is_configured() { return 0; }
+nordvpn_easy_preferred_server_matches_current() { return 1; }
+nordvpn_easy_apply_preferred_server_from_catalog() { return 0; }
+nordvpn_easy_apply_server_change_runtime() {
+	APPLY_COUNT=$((APPLY_COUNT + 1))
+	if [ "$APPLY_COUNT" -le "$APPLY_FAIL_UNTIL" ]; then
+		return 1
+	fi
+	return 0
+}
 
 uci() {
 	if [ "$1" = 'commit' ] && [ "$2" = 'network' ]; then
@@ -97,14 +103,6 @@ uci() {
 		return 0
 	fi
 
-	return 0
-}
-
-apply_server_change_runtime() {
-	APPLY_COUNT=$((APPLY_COUNT + 1))
-	if [ "$APPLY_COUNT" -le "$APPLY_FAIL_UNTIL" ]; then
-		return 1
-	fi
 	return 0
 }
 

--- a/tests/nordvpn-easy/test-catalog-fixtures.sh
+++ b/tests/nordvpn-easy/test-catalog-fixtures.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+CATALOG_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh"
+FIXTURE="$ROOT_DIR/tests/nordvpn-easy/fixtures/nordvpn-api-servers.json"
+TMP_DIR="$(mktemp -d)"
+CATALOG_JSON="$TMP_DIR/catalog.json"
+TS_FILE="$TMP_DIR/catalog.timestamp"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+# shellcheck disable=SC1090
+. "$CATALOG_LIB"
+
+assert_jq() {
+	filter="$1"
+	file="$2"
+	label="$3"
+
+	if ! jq -er "$filter" "$file" >/dev/null 2>&1; then
+		printf '%s\n' "FAIL: $label" >&2
+		jq '.' "$file" >&2
+		exit 1
+	fi
+}
+
+nordvpn_easy_build_server_catalog_json 237 IT Italy < "$FIXTURE" > "$CATALOG_JSON"
+
+assert_jq '.country_id == 237' "$CATALOG_JSON" 'country id preserved'
+assert_jq '.country_code == "IT"' "$CATALOG_JSON" 'country code preserved'
+assert_jq '.servers | length == 2' "$CATALOG_JSON" 'offline and invalid servers filtered out'
+assert_jq '.servers[0].hostname == "it12.nordvpn.com"' "$CATALOG_JSON" 'servers sorted by load'
+assert_jq '.servers[1].station == "it456"' "$CATALOG_JSON" 'station exported'
+
+nordvpn_easy_server_catalog_has_servers "$CATALOG_JSON"
+
+TSV_OUTPUT="$(nordvpn_easy_server_catalog_candidates_tsv "$CATALOG_JSON")"
+printf '%s\n' "$TSV_OUTPUT" | grep -F 'it12.nordvpn.com' >/dev/null
+printf '%s\n' "$TSV_OUTPUT" | grep -F 'PUBKEY-456' >/dev/null
+
+printf '%s\n' '1711796400' > "$TS_FILE"
+nordvpn_easy_emit_server_catalog_json "$CATALOG_JSON" "$TS_FILE" 3600 > "$TMP_DIR/catalog-emitted.json"
+
+assert_jq '.cached_at == 1711796400' "$TMP_DIR/catalog-emitted.json" 'cached_at metadata emitted'
+assert_jq '.cache_ttl == 3600' "$TMP_DIR/catalog-emitted.json" 'cache ttl metadata emitted'
+
+printf '%s\n' 'test-catalog-fixtures.sh: ok'

--- a/tests/nordvpn-easy/test-catalog-fixtures.sh
+++ b/tests/nordvpn-easy/test-catalog-fixtures.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)"
 CATALOG_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/catalog.sh"
 FIXTURE="$ROOT_DIR/tests/nordvpn-easy/fixtures/nordvpn-api-servers.json"
 TMP_DIR="$(mktemp -d)"

--- a/tests/nordvpn-easy/test-common-lock.sh
+++ b/tests/nordvpn-easy/test-common-lock.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+COMMON_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+# shellcheck disable=SC1090
+. "$COMMON_LIB"
+
+assert_eq() {
+	expected="$1"
+	actual="$2"
+	label="$3"
+
+	if [ "$expected" != "$actual" ]; then
+		printf '%s\n' "FAIL: $label" >&2
+		printf '%s\n' "expected: $expected" >&2
+		printf '%s\n' "actual:   $actual" >&2
+		exit 1
+	fi
+}
+
+ACTION='server_catalog'
+LOCK_DIR="$TMP_DIR/lock"
+LOCK_ACQUIRED=0
+
+nordvpn_easy_log() { :; }
+
+first_rc=0
+nordvpn_easy_acquire_lock >/dev/null 2>&1 || first_rc=$?
+assert_eq '0' "$first_rc" 'first lock acquisition'
+
+second_rc=0
+nordvpn_easy_acquire_lock >/dev/null 2>&1 || second_rc=$?
+assert_eq '2' "$second_rc" 'second acquisition reports contention'
+
+nordvpn_easy_release_lock
+[ ! -d "$LOCK_DIR" ] || {
+	printf '%s\n' 'FAIL: lock directory was not removed' >&2
+	exit 1
+}
+
+mkdir -p "$LOCK_DIR"
+printf '%s\n' '999999' > "$LOCK_DIR/pid"
+printf '%s\n' 'stale' > "$LOCK_DIR/action"
+LOCK_ACQUIRED=0
+
+stale_rc=0
+nordvpn_easy_acquire_lock >/dev/null 2>&1 || stale_rc=$?
+assert_eq '0' "$stale_rc" 'stale lock recovery'
+nordvpn_easy_release_lock
+
+printf '%s\n' 'test-common-lock.sh: ok'

--- a/tests/nordvpn-easy/test-common-lock.sh
+++ b/tests/nordvpn-easy/test-common-lock.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)"
 COMMON_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh"
 TMP_DIR="$(mktemp -d)"
 

--- a/tests/nordvpn-easy/test-runtime.sh
+++ b/tests/nordvpn-easy/test-runtime.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+RUNTIME_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/runtime.sh"
+
+# shellcheck disable=SC1090
+. "$RUNTIME_LIB"
+
+assert_eq() {
+	expected="$1"
+	actual="$2"
+	label="$3"
+
+	if [ "$expected" != "$actual" ]; then
+		printf '%s\n' "FAIL: $label" >&2
+		printf '%s\n' "expected: $expected" >&2
+		printf '%s\n' "actual:   $actual" >&2
+		exit 1
+	fi
+}
+
+WG_DUMP="$(printf '%b\n' \
+	'private\tpublic\t51820\tfwmark' \
+	'peerpub\tpsk\tit12.nordvpn.com:51820\t10.5.0.2/32\t1711796400\t2048\t4096\t25')"
+
+PARSED="$(nordvpn_easy_parse_wg_dump_peer "$WG_DUMP")"
+
+assert_eq "$(printf 'it12.nordvpn.com:51820\t1711796400\t2048\t4096')" "$PARSED" 'wg dump parsing'
+assert_eq 'Never' "$(nordvpn_easy_humanize_handshake_age 0)" 'zero handshake age'
+assert_eq '2.00 KiB' "$(nordvpn_easy_format_human_bytes 2048)" 'byte formatting'
+
+printf '%s\n' 'test-runtime.sh: ok'

--- a/tests/nordvpn-easy/test-runtime.sh
+++ b/tests/nordvpn-easy/test-runtime.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)"
 RUNTIME_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/runtime.sh"
 
 # shellcheck disable=SC1090

--- a/tests/nordvpn-easy/test-schema.sh
+++ b/tests/nordvpn-easy/test-schema.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)"
 SCHEMA_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/schema.sh"
 
 # shellcheck disable=SC1090

--- a/tests/nordvpn-easy/test-schema.sh
+++ b/tests/nordvpn-easy/test-schema.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+SCHEMA_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/schema.sh"
+
+# shellcheck disable=SC1090
+. "$SCHEMA_LIB"
+
+assert_eq() {
+	expected="$1"
+	actual="$2"
+	label="$3"
+
+	if [ "$expected" != "$actual" ]; then
+		printf '%s\n' "FAIL: $label" >&2
+		printf '%s\n' "expected: $expected" >&2
+		printf '%s\n' "actual:   $actual" >&2
+		exit 1
+	fi
+}
+
+assert_eq 'auto' "$(nordvpn_easy_default server_selection_mode)" 'default server selection mode'
+assert_eq '86400' "$(nordvpn_easy_default server_cache_ttl)" 'default server cache ttl'
+assert_eq '1' "$(nordvpn_easy_normalize_value enabled yes)" 'boolean normalization for yes'
+assert_eq '1' "$(nordvpn_easy_normalize_value enabled true)" 'boolean normalization for true'
+assert_eq 'manual' "$(nordvpn_easy_normalize_value server_selection_mode manual)" 'manual mode normalization'
+assert_eq 'auto' "$(nordvpn_easy_normalize_value server_selection_mode broken)" 'invalid mode normalization'
+assert_eq '86400' "$(nordvpn_easy_normalize_value server_cache_ttl not-a-number)" 'invalid ttl normalization'
+assert_eq "$NORDVPN_EASY_SCHEMA_VERSION" "$(nordvpn_easy_normalize_value config_schema_version 0)" 'schema version normalization'
+
+unset NORDVPN_TOKEN
+unset CHECK_CRON_SCHEDULE
+SERVER_CACHE_TTL=''
+export SERVER_CACHE_TTL
+nordvpn_easy_apply_env_defaults
+
+assert_eq '' "${NORDVPN_TOKEN:-}" 'empty token default'
+assert_eq '* * * * *' "$CHECK_CRON_SCHEDULE" 'cron default with spaces'
+assert_eq '86400' "$SERVER_CACHE_TTL" 'environment ttl default'
+
+printf '%s\n' 'test-schema.sh: ok'

--- a/tests/nordvpn-easy/test-service-config.sh
+++ b/tests/nordvpn-easy/test-service-config.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+SCHEMA_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/schema.sh"
+SERVICE_CONFIG_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/service-config.sh"
+TMP_DIR="$(mktemp -d)"
+UCI_DB="$TMP_DIR/uci"
+COMMIT_COUNT=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$UCI_DB"
+
+# shellcheck disable=SC1090
+. "$SCHEMA_LIB"
+# shellcheck disable=SC1090
+. "$SERVICE_CONFIG_LIB"
+
+assert_eq() {
+	expected="$1"
+	actual="$2"
+	label="$3"
+
+	if [ "$expected" != "$actual" ]; then
+		printf '%s\n' "FAIL: $label" >&2
+		printf '%s\n' "expected: $expected" >&2
+		printf '%s\n' "actual:   $actual" >&2
+		exit 1
+	fi
+}
+
+uci_path() {
+	printf '%s/%s\n' "$UCI_DB" "$(printf '%s' "$1" | tr '.=' '__')"
+}
+
+uci() {
+	quiet=0
+	if [ "${1:-}" = '-q' ]; then
+		quiet=1
+		shift
+	fi
+
+	cmd="${1:-}"
+	shift || true
+
+	case "$cmd" in
+		get)
+			file="$(uci_path "$1")"
+			[ -f "$file" ] || return 1
+			cat "$file"
+			;;
+		set)
+			target="$1"
+			key="${target%%=*}"
+			value="${target#*=}"
+			printf '%s' "$value" > "$(uci_path "$key")"
+			;;
+		delete)
+			rm -f "$(uci_path "$1")"
+			;;
+		commit)
+			COMMIT_COUNT=$((COMMIT_COUNT + 1))
+			;;
+		*)
+			[ "$quiet" -eq 1 ] || printf '%s\n' "unsupported uci command: $cmd" >&2
+			return 1
+			;;
+	esac
+}
+
+printf '%s' 'legacy' > "$(uci_path 'nordvpn_easy.main.nordvpn_basic_token')"
+printf '%s' 'yes' > "$(uci_path 'nordvpn_easy.main.enabled')"
+printf '%s' 'oops' > "$(uci_path 'nordvpn_easy.main.server_cache_ttl')"
+
+nordvpn_easy_migrate_service_config nordvpn_easy main
+
+assert_eq '1' "$(cat "$(uci_path 'nordvpn_easy.main.enabled')")" 'enabled normalized'
+assert_eq '86400' "$(cat "$(uci_path 'nordvpn_easy.main.server_cache_ttl')")" 'ttl backfilled'
+assert_eq "$NORDVPN_EASY_SCHEMA_VERSION" "$(cat "$(uci_path 'nordvpn_easy.main.config_schema_version')")" 'schema version set'
+[ ! -f "$(uci_path 'nordvpn_easy.main.nordvpn_basic_token')" ] || {
+	printf '%s\n' 'FAIL: legacy token key was not removed' >&2
+	exit 1
+}
+assert_eq '1' "$COMMIT_COUNT" 'single migration commit'
+
+printf '%s\n' 'test-service-config.sh: ok'

--- a/tests/nordvpn-easy/test-service-config.sh
+++ b/tests/nordvpn-easy/test-service-config.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)"
 SCHEMA_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/schema.sh"
 SERVICE_CONFIG_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/service-config.sh"
 TMP_DIR="$(mktemp -d)"


### PR DESCRIPTION
- **Add server catalog cache UI and remove top action bar**
- **Add NordVPN Easy manager UI, service & CI**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned UI controls and labels, richer server summaries, relative-time display, improved country/server selection, and explicit Network & Runtime sections (Cache & Catalog, Health Checks & Recovery, Runtime Actions).
  * Automatic/manual server selection, rotation, bootstrap and runtime apply flows with confirmation modals and log export.

* **Bug Fixes**
  * More robust status polling, handshake/transfer reporting, service action error handling, config migration, and VPN interface recovery.

* **Chores**
  * Split frontend/backend into modular components and added a CI Quality workflow to run static checks and tests.

* **Tests**
  * Added fixture-driven tests covering schema, catalog, runtime, actions, migration, and locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->