### PR TITLE
Wrap modules with baseclass.extend

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-data.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-data.js
@@ -1,4 +1,5 @@
 'use strict';
+'require baseclass';
 
 function normalizeCountryCode(value) {
 	return String(value || '').trim().toUpperCase();
@@ -99,7 +100,7 @@ function buildServerCatalogIndex(catalog) {
 	return index;
 }
 
-return {
+return baseclass.extend({
 	normalizeCountryCode: normalizeCountryCode,
 	emptyServerCatalog: emptyServerCatalog,
 	parseJson: parseJson,
@@ -107,4 +108,4 @@ return {
 	parseLocalStatus: parseLocalStatus,
 	parseServerCatalog: parseServerCatalog,
 	buildServerCatalogIndex: buildServerCatalogIndex
-};
+});

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-format.js
@@ -1,4 +1,5 @@
 'use strict';
+'require baseclass';
 
 function humanizeAction(action) {
 	return String(action || _('operation')).replace(/_/g, ' ');
@@ -90,11 +91,11 @@ function formatRelativeTimestamp(epochSeconds) {
 	return formatRelativeAge((Date.now() / 1000) - ts);
 }
 
-return {
+return baseclass.extend({
 	humanizeAction: humanizeAction,
 	formatActionsLabel: formatActionsLabel,
 	formatServerLabel: formatServerLabel,
 	formatServerSummary: formatServerSummary,
 	formatRelativeAge: formatRelativeAge,
 	formatRelativeTimestamp: formatRelativeTimestamp
-};
+});

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-state.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-state.js
@@ -1,4 +1,5 @@
 'use strict';
+'require baseclass';
 'require fs';
 'require nordvpn-easy/manager-data as managerData';
 'require nordvpn-easy/manager-format as managerFormat';
@@ -417,7 +418,7 @@ function handleSaveApply(viewState, state, ev, mode) {
 	});
 }
 
-return {
+return baseclass.extend({
 	createState: createState,
 	loadServerCatalog: loadServerCatalog,
 	updatePublicIp: updatePublicIp,
@@ -427,4 +428,4 @@ return {
 	onModeChanged: onModeChanged,
 	handleRefreshServerCatalog: handleRefreshServerCatalog,
 	handleSaveApply: handleSaveApply
-};
+});

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-ui.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-ui.js
@@ -1,4 +1,5 @@
 'use strict';
+'require baseclass';
 'require nordvpn-easy/manager-data as managerData';
 'require nordvpn-easy/manager-format as managerFormat';
 'require ui';
@@ -415,7 +416,7 @@ function renderStatusSection() {
 	]);
 }
 
-return {
+return baseclass.extend({
 	ids: ids,
 	getSelectElement: getSelectElement,
 	getInputElement: getInputElement,
@@ -436,4 +437,4 @@ return {
 	updateServerSelectionState: updateServerSelectionState,
 	showConfirmationModal: showConfirmationModal,
 	renderStatusSection: renderStatusSection
-};
+});

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
@@ -1,4 +1,5 @@
 'use strict';
+'require baseclass';
 'require fs';
 'require ui';
 
@@ -116,7 +117,7 @@ function downloadTextFile(name, content) {
 	window.URL.revokeObjectURL(url);
 }
 
-return {
+return baseclass.extend({
 	parseJson: parseJson,
 	parseExecJsonResponse: parseExecJsonResponse,
 	responseMessage: responseMessage,
@@ -127,4 +128,4 @@ return {
 	notifyInfo: notifyInfo,
 	notifyError: notifyError,
 	downloadTextFile: downloadTextFile
-};
+});


### PR DESCRIPTION
Add 'require baseclass' and replace plain object exports with baseclass.extend(...) in manager-data.js, manager-format.js, manager-state.js, manager-ui.js, and service.js. This standardizes the module export pattern to use the baseclass layer for easier extension and consistent behavior; no functional logic changes were made.

LiveReview Pre-Commit Check: skipped (iter:1, coverage:0%)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal module architecture for improved code maintainability and consistency across the NordVPN Easy application without affecting user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->