### PR TITLE
Harden NordVPN OpenWrt packaging, RPCD cleanup, diagnostics, and WireGuard recovery

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+reviews:
+  tools:
+    github-checks:
+      enabled: true
+      timeout_ms: 900000

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,6 +322,9 @@ jobs:
             "${VERIFY_DIR}/etc/config/nordvpn_easy" \
             "${VERIFY_DIR}/etc/init.d/nordvpn-easy" \
             "${VERIFY_DIR}/usr/libexec/nordvpn-easy/core.sh" \
+            "${VERIFY_DIR}/usr/libexec/nordvpn-easy/lib/config-context.sh" \
+            "${VERIFY_DIR}/usr/libexec/nordvpn-easy/lib/runtime.sh" \
+            "${VERIFY_DIR}/usr/libexec/rpcd/nordvpn.easy" \
             "${VERIFY_DIR}/www/luci-static/resources/view/nordvpn-easy/config.js"
           do
             if [ ! -f "$required_path" ]; then
@@ -335,7 +338,8 @@ jobs:
             "name: luci-app-nordvpn-easy.conffiles" \
             "name: luci-app-nordvpn-easy.conffiles_static" \
             "post-install: |" \
-            "post-upgrade: |"
+            "post-upgrade: |" \
+            "post-deinstall: |"
           do
             if ! grep -Fq "$required_metadata" "$ADB_DUMP"; then
               echo "::error::Built APK is missing required metadata marker: $required_metadata"
@@ -541,6 +545,13 @@ jobs:
           install -d -m0755 "${LUCI_ROOT}/usr/libexec/nordvpn-easy"
           install -m0755 "${BACKEND_FILES}/usr/libexec/nordvpn-easy/core.sh" \
             "${LUCI_ROOT}/usr/libexec/nordvpn-easy/core.sh"
+          install -d -m0755 "${LUCI_ROOT}/usr/libexec/nordvpn-easy/lib"
+          cp -R "${BACKEND_FILES}/usr/libexec/nordvpn-easy/lib/." \
+            "${LUCI_ROOT}/usr/libexec/nordvpn-easy/lib/"
+
+          install -d -m0755 "${LUCI_ROOT}/usr/libexec/rpcd"
+          install -m0755 "${BACKEND_FILES}/usr/libexec/rpcd/nordvpn.easy" \
+            "${LUCI_ROOT}/usr/libexec/rpcd/nordvpn.easy"
 
       - name: Initialize OpenWrt SDK configuration
         run: |
@@ -667,6 +678,9 @@ jobs:
             "${VERIFY_DIR}/data/etc/config/nordvpn_easy" \
             "${VERIFY_DIR}/data/etc/init.d/nordvpn-easy" \
             "${VERIFY_DIR}/data/usr/libexec/nordvpn-easy/core.sh" \
+            "${VERIFY_DIR}/data/usr/libexec/nordvpn-easy/lib/config-context.sh" \
+            "${VERIFY_DIR}/data/usr/libexec/nordvpn-easy/lib/runtime.sh" \
+            "${VERIFY_DIR}/data/usr/libexec/rpcd/nordvpn.easy" \
             "${VERIFY_DIR}/data/www/luci-static/resources/view/nordvpn-easy/config.js"
           do
             if [ ! -f "$required_path" ]; then
@@ -689,6 +703,11 @@ jobs:
 
           if [ ! -f "${VERIFY_DIR}/control/postinst" ]; then
             echo "::error::Built IPK is missing postinst script"
+            exit 1
+          fi
+
+          if [ ! -f "${VERIFY_DIR}/control/postrm" ]; then
+            echo "::error::Built IPK is missing postrm script"
             exit 1
           fi
 

--- a/openwrt-packages/luci-app-nordvpn-easy/Makefile
+++ b/openwrt-packages/luci-app-nordvpn-easy/Makefile
@@ -21,6 +21,21 @@ define Package/$(PKG_NAME)/conffiles
 /etc/config/nordvpn_easy
 endef
 
+define Package/$(PKG_NAME)/prerm
+#!/bin/sh
+
+[ -n "$${IPKG_INSTROOT}" ] && exit 0
+[ "$${PKG_UPGRADE:-0}" = "1" ] && exit 0
+
+case "$${1:-}" in
+	remove|purge)
+		rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg
+		;;
+esac
+
+exit 0
+endef
+
 define Package/$(PKG_NAME)/postinst
 #!/bin/sh
 

--- a/openwrt-packages/luci-app-nordvpn-easy/Makefile
+++ b/openwrt-packages/luci-app-nordvpn-easy/Makefile
@@ -27,7 +27,22 @@ define Package/$(PKG_NAME)/prerm
 [ -n "$${IPKG_INSTROOT}" ] && exit 0
 [ "$${PKG_UPGRADE:-0}" = "1" ] && exit 0
 
-case "$${1:-}" in
+case "$${1:-remove}" in
+	remove|purge)
+		rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg
+		;;
+esac
+
+exit 0
+endef
+
+define Package/$(PKG_NAME)/postrm
+#!/bin/sh
+
+[ -n "$${IPKG_INSTROOT}" ] && exit 0
+[ "$${PKG_UPGRADE:-0}" = "1" ] && exit 0
+
+case "$${1:-remove}" in
 	remove|purge)
 		rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg
 		;;

--- a/openwrt-packages/luci-app-nordvpn-easy/Makefile
+++ b/openwrt-packages/luci-app-nordvpn-easy/Makefile
@@ -21,21 +21,6 @@ define Package/$(PKG_NAME)/conffiles
 /etc/config/nordvpn_easy
 endef
 
-define Package/$(PKG_NAME)/prerm
-#!/bin/sh
-
-[ -n "$${IPKG_INSTROOT}" ] && exit 0
-[ "$${PKG_UPGRADE:-0}" = "1" ] && exit 0
-
-case "$${1:-remove}" in
-	remove|purge)
-		rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg
-		;;
-esac
-
-exit 0
-endef
-
 define Package/$(PKG_NAME)/postrm
 #!/bin/sh
 

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
@@ -87,6 +87,22 @@ const callRefreshServers = rpc.declare({
 	params: [ 'country', 'force' ]
 });
 
+function rpcErrorMessage(err) {
+	return (err && err.message) ? String(err.message) : String(err);
+}
+
+function normalizeRpcError(err) {
+	const message = rpcErrorMessage(err);
+
+	if (message.indexOf('Object not found') !== -1) {
+		return new Error(
+			_('NordVPN Easy backend RPC object is not registered. Reinstall or upgrade luci-app-nordvpn-easy, reload rpcd, then refresh LuCI.')
+		);
+	}
+
+	return err;
+}
+
 function parseJson(raw, fallback) {
 	try {
 		return JSON.parse(raw || '');
@@ -236,6 +252,8 @@ function execService(action, extraArgs) {
 
 	return request.then(function(payload) {
 		return normalizeExecResult(action, payload);
+	}).catch(function(err) {
+		throw normalizeRpcError(err);
 	});
 }
 

--- a/openwrt-packages/nordvpn-easy/Makefile
+++ b/openwrt-packages/nordvpn-easy/Makefile
@@ -34,6 +34,21 @@ define Package/nordvpn-easy/conffiles
 /etc/config/nordvpn_easy
 endef
 
+define Package/nordvpn-easy/prerm
+#!/bin/sh
+
+[ -n "$${IPKG_INSTROOT}" ] && exit 0
+[ "$${PKG_UPGRADE:-0}" = "1" ] && exit 0
+
+case "$${1:-}" in
+	remove|purge)
+		rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg
+		;;
+esac
+
+exit 0
+endef
+
 define Build/Compile
 endef
 

--- a/openwrt-packages/nordvpn-easy/Makefile
+++ b/openwrt-packages/nordvpn-easy/Makefile
@@ -34,29 +34,29 @@ define Package/nordvpn-easy/conffiles
 /etc/config/nordvpn_easy
 endef
 
-define Package/nordvpn-easy/prerm
-#!/bin/sh
-
-[ -n "$${IPKG_INSTROOT}" ] && exit 0
-[ "$${PKG_UPGRADE:-0}" = "1" ] && exit 0
-
-case "$${1:-remove}" in
-	remove|purge)
-		rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg
-		;;
-esac
-
-exit 0
-endef
-
 define Package/nordvpn-easy/postrm
 #!/bin/sh
 
+luci_app_installed() {
+	if command -v opkg >/dev/null 2>&1 && opkg status luci-app-nordvpn-easy >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if command -v apk >/dev/null 2>&1 && apk info -e luci-app-nordvpn-easy >/dev/null 2>&1; then
+		return 0
+	fi
+
+	return 1
+}
+
 [ -n "$${IPKG_INSTROOT}" ] && exit 0
 [ "$${PKG_UPGRADE:-0}" = "1" ] && exit 0
 
 case "$${1:-remove}" in
 	remove|purge)
+		if luci_app_installed; then
+			exit 0
+		fi
 		rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg
 		;;
 esac

--- a/openwrt-packages/nordvpn-easy/Makefile
+++ b/openwrt-packages/nordvpn-easy/Makefile
@@ -40,7 +40,22 @@ define Package/nordvpn-easy/prerm
 [ -n "$${IPKG_INSTROOT}" ] && exit 0
 [ "$${PKG_UPGRADE:-0}" = "1" ] && exit 0
 
-case "$${1:-}" in
+case "$${1:-remove}" in
+	remove|purge)
+		rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg
+		;;
+esac
+
+exit 0
+endef
+
+define Package/nordvpn-easy/postrm
+#!/bin/sh
+
+[ -n "$${IPKG_INSTROOT}" ] && exit 0
+[ "$${PKG_UPGRADE:-0}" = "1" ] && exit 0
+
+case "$${1:-remove}" in
 	remove|purge)
 		rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg
 		;;

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -364,8 +364,13 @@ countries_cache_is_fresh () {
 refresh_countries_cache () {
   FORCE_REFRESH="${1:-0}"
   COUNTRIES_TEMP_DIR=''
+  COUNTRIES_RAW_TMP=''
   COUNTRIES_CACHE_TMP=''
   COUNTRIES_TS_TMP=''
+  COUNTRIES_CURL_STDERR=''
+  COUNTRIES_CURL_RC=0
+  COUNTRIES_CURL_ERROR=''
+  COUNTRIES_FAILURE_REASON=''
 
   if [ "$FORCE_REFRESH" -ne 1 ] && countries_cache_is_fresh; then
     log "Using cached NordVPN country list from $COUNTRIES_CACHE_FILE"
@@ -379,9 +384,28 @@ refresh_countries_cache () {
   fi
 
   nordvpn_easy_mktemp_dir 'countries-cache' COUNTRIES_TEMP_DIR || return 1
+  COUNTRIES_RAW_TMP="$(nordvpn_easy_temp_file_path "$COUNTRIES_TEMP_DIR" 'countries-api.json')"
   COUNTRIES_CACHE_TMP="$(nordvpn_easy_temp_file_path "$COUNTRIES_TEMP_DIR" 'countries.json')"
   COUNTRIES_TS_TMP="$(nordvpn_easy_temp_file_path "$COUNTRIES_TEMP_DIR" 'countries.timestamp')"
-  curl -fsS --connect-timeout 15 --max-time 30 "$COUNTRIES_URL" | jq -ce '
+  COUNTRIES_CURL_STDERR="$(nordvpn_easy_temp_file_path "$COUNTRIES_TEMP_DIR" 'curl-stderr.log')"
+
+  curl -fsS --connect-timeout 15 --max-time 30 -o "$COUNTRIES_RAW_TMP" "$COUNTRIES_URL" 2>"$COUNTRIES_CURL_STDERR" || {
+    COUNTRIES_CURL_RC=$?
+    COUNTRIES_CURL_ERROR="$(nordvpn_easy_curl_error_summary "$COUNTRIES_CURL_STDERR")"
+    COUNTRIES_FAILURE_REASON="country list refresh failed (curl_rc=$COUNTRIES_CURL_RC: $(curl_rc_meaning "$COUNTRIES_CURL_RC")"
+    [ -n "$COUNTRIES_CURL_ERROR" ] && COUNTRIES_FAILURE_REASON="$COUNTRIES_FAILURE_REASON, curl_error=$COUNTRIES_CURL_ERROR"
+    COUNTRIES_FAILURE_REASON="$COUNTRIES_FAILURE_REASON)"
+    rm -rf -- "$COUNTRIES_TEMP_DIR"
+    if [ -f "$COUNTRIES_CACHE_FILE" ]; then
+      log "WARNING: $COUNTRIES_FAILURE_REASON; using existing cache"
+      return 0
+    fi
+    nordvpn_easy_record_last_error "could not refresh country list cache ($COUNTRIES_FAILURE_REASON)"
+    log "ERROR: COULD NOT REFRESH COUNTRY LIST CACHE ($COUNTRIES_FAILURE_REASON)"
+    return 1
+  }
+
+  jq -ce '
     [ .[] | select(
         (.id != null) and
         ((.name // "") != "") and
@@ -392,13 +416,14 @@ refresh_countries_cache () {
         code: .code
       }
     ] | sort_by(.name | ascii_downcase)
-  ' > "$COUNTRIES_CACHE_TMP" 2>/dev/null || {
+  ' "$COUNTRIES_RAW_TMP" > "$COUNTRIES_CACHE_TMP" 2>/dev/null || {
     rm -rf -- "$COUNTRIES_TEMP_DIR"
     if [ -f "$COUNTRIES_CACHE_FILE" ]; then
-      log 'WARNING: country list refresh failed; using existing cache'
+      log 'WARNING: country list refresh produced invalid JSON; using existing cache'
       return 0
     fi
-    log 'ERROR: COULD NOT REFRESH COUNTRY LIST CACHE'
+    nordvpn_easy_record_last_error 'country list refresh produced invalid JSON and no existing cache is available'
+    log 'ERROR: COULD NOT REFRESH COUNTRY LIST CACHE (invalid JSON response)'
     return 1
   }
 

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
@@ -220,17 +220,27 @@ nordvpn_easy_use_cached_server_list_if_available() {
 nordvpn_easy_get_servers_list() {
 	local temp_dir=''
 	local server_list_tmp=''
+	local server_list_stderr=''
+	local curl_rc=0
+	local curl_error=''
+	local failure_reason=''
 	SERVER_RECOMMENDATIONS_URL=$(nordvpn_easy_build_server_recommendations_url) || return 1
 
 	nordvpn_easy_mktemp_dir 'server-list' temp_dir || return 1
 	server_list_tmp="$(nordvpn_easy_temp_file_path "$temp_dir" 'recommendations.json')"
+	server_list_stderr="$(nordvpn_easy_temp_file_path "$temp_dir" 'curl-stderr.log')"
 
 	log "apply: downloading recommended VPN server list to $server_list_tmp"
 
-	curl -g -fsS --connect-timeout 15 --max-time 30 -o "$server_list_tmp" "$SERVER_RECOMMENDATIONS_URL" || {
+	curl -g -fsS --connect-timeout 15 --max-time 30 -o "$server_list_tmp" "$SERVER_RECOMMENDATIONS_URL" 2>"$server_list_stderr" || {
+		curl_rc=$?
+		curl_error="$(nordvpn_easy_curl_error_summary "$server_list_stderr")"
+		failure_reason="could not retrieve VPN servers (curl_rc=$curl_rc: $(nordvpn_easy_curl_rc_meaning "$curl_rc")"
+		[ -n "$curl_error" ] && failure_reason="$failure_reason, curl_error=$curl_error"
+		failure_reason="$failure_reason)"
 		rm -rf -- "$temp_dir"
-		nordvpn_easy_use_cached_server_list_if_available 'could not retrieve VPN servers' && return 0
-		log 'ERROR: COULD NOT RETRIEVE VPN SERVERS'
+		nordvpn_easy_use_cached_server_list_if_available "$failure_reason" && return 0
+		log "ERROR: COULD NOT RETRIEVE VPN SERVERS (curl_rc=$curl_rc: $(nordvpn_easy_curl_rc_meaning "$curl_rc")$([ -n "$curl_error" ] && printf ', curl_error=%s' "$curl_error"))"
 		return 1
 	}
 
@@ -639,6 +649,9 @@ nordvpn_easy_repair_missing_wireguard_peer() {
 }
 
 nordvpn_easy_bootstrap_if_needed() {
+	local base_settings_changed=0
+	local transport_settings_changed=0
+
 	nordvpn_easy_require_core_action_helpers refresh_countries_cache || return 1
 	log "runtime: bootstrap starting for interface $VPN_IF (mode=${SERVER_SELECTION_MODE:-auto}, country=${VPN_COUNTRY:-automatic})"
 	nordvpn_easy_log_vpn_interface_state 'bootstrap-start'
@@ -657,17 +670,17 @@ nordvpn_easy_bootstrap_if_needed() {
 		nordvpn_easy_retry_pending_network_reload || return 1
 		log "runtime: interface $VPN_IF is already configured; ensuring it is enabled and present"
 		nordvpn_easy_ensure_vpn_interface_enabled || return 1
+		nordvpn_easy_repair_wireguard_interface_base_settings || return 1
+		base_settings_changed="${NORDVPN_EASY_UCI_CHANGED:-0}"
 		nordvpn_easy_apply_wireguard_transport_settings "${VPN_IF}server" || return 1
-		if [ "${NORDVPN_EASY_UCI_CHANGED:-0}" -eq 1 ]; then
-			log "runtime: repaired WireGuard transport settings for $VPN_IF (keepalive=${WIREGUARD_PERSISTENT_KEEPALIVE:-15}, mtu=${WIREGUARD_MTU:-auto})"
+		transport_settings_changed="${NORDVPN_EASY_UCI_CHANGED:-0}"
+		if [ "$base_settings_changed" -eq 1 ] || [ "$transport_settings_changed" -eq 1 ]; then
+			log "runtime: repaired WireGuard settings for $VPN_IF (base=${base_settings_changed}, transport=${transport_settings_changed}, keepalive=${WIREGUARD_PERSISTENT_KEEPALIVE:-15}, mtu=${WIREGUARD_MTU:-auto})"
 			uci commit network || {
-				nordvpn_easy_log_blocker "${LOG_PHASE:-runtime}" 'could not commit network configuration while repairing WireGuard transport settings'
+				nordvpn_easy_log_blocker "${LOG_PHASE:-runtime}" 'could not commit network configuration while repairing WireGuard settings'
 				return 1
 			}
-			/etc/init.d/network reload || {
-				log "ERROR: NETWORK RELOAD FAILED WHILE REPAIRING WIREGUARD TRANSPORT SETTINGS ON $VPN_IF"
-				return 1
-			}
+			nordvpn_easy_reload_network_for_wireguard 'repairing WireGuard settings' || return 1
 		fi
 	fi
 

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
@@ -155,6 +155,14 @@ nordvpn_easy_curl_rc_meaning() {
 	esac
 }
 
+nordvpn_easy_curl_error_summary() {
+	local error_file="$1"
+
+	sed -n '1,3p' "$error_file" 2>/dev/null |
+		tr '\r\n' '  ' |
+		nordvpn_easy_sanitize_diagnostics_stream
+}
+
 nordvpn_easy_json_escape() {
 	printf '%s' "$1" | sed ':a;N;$!ba;s/\\/\\\\/g;s/"/\\"/g;s/\n/\\n/g;s/\r/\\r/g'
 }
@@ -471,6 +479,7 @@ nordvpn_easy_print_diagnostics_health_summary() {
 	local link_present='unknown'
 	local routes_via_vpn='unknown'
 	local wg_peer_count='unknown'
+	local missing_interface=''
 	local missing_required=''
 	local probable_issue='none detected'
 	local value=''
@@ -484,6 +493,14 @@ nordvpn_easy_print_diagnostics_health_summary() {
 			private_key_state='present'
 		else
 			private_key_state='missing'
+		fi
+
+		if [ "$vpn_proto" = 'wireguard' ]; then
+			for value in private_key addresses peerdns delegate force_link; do
+				if ! uci -q get "network.${vpn_if}.${value}" >/dev/null 2>&1; then
+					missing_interface="$(nordvpn_easy_diagnostics_csv_append "$missing_interface" "$value")"
+				fi
+			done
 		fi
 
 		peer_sections="$(
@@ -527,7 +544,9 @@ nordvpn_easy_print_diagnostics_health_summary() {
 		wg_peer_count="$(wg show "$vpn_if" peers 2>/dev/null | awk 'NF { count++ } END { print count + 0 }')"
 	fi
 
-	if [ "$vpn_proto" = 'wireguard' ] && [ "$peer_section_found" != 'yes' ]; then
+	if [ "$vpn_proto" = 'wireguard' ] && [ -n "$missing_interface" ]; then
+		probable_issue="wireguard interface is incomplete (${missing_interface})"
+	elif [ "$vpn_proto" = 'wireguard' ] && [ "$peer_section_found" != 'yes' ]; then
 		probable_issue='wireguard interface exists but peer section is missing'
 	elif [ "$vpn_proto" = 'wireguard' ] && [ -n "$missing_required" ]; then
 		probable_issue="wireguard peer section is incomplete (${missing_required})"
@@ -542,6 +561,7 @@ nordvpn_easy_print_diagnostics_health_summary() {
 	printf 'vpn_proto=%s\n' "$vpn_proto"
 	printf 'interface_disabled=%s\n' "$interface_disabled"
 	printf 'private_key=%s\n' "$private_key_state"
+	printf 'required_interface_keys_missing=%s\n' "${missing_interface:-none}"
 	printf 'convention_peer_section=%sserver\n' "$vpn_if"
 	printf 'peer_section_found=%s\n' "$peer_section_found"
 	printf 'peer_section=%s\n' "${peer_section:-none}"

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/wireguard.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/wireguard.sh
@@ -279,6 +279,60 @@ nordvpn_easy_delete_uci_option_if_present() {
 	NORDVPN_EASY_UCI_CHANGED=1
 }
 
+nordvpn_easy_set_uci_list_if_changed() {
+	local key="$1"
+	local current=''
+	local expected=''
+	local value=''
+
+	shift
+	current="$(uci -q get "$key" 2>/dev/null || true)"
+	expected="$*"
+	[ "$current" = "$expected" ] && return 0
+
+	uci -q delete "$key" 2>/dev/null || true
+	for value in "$@"; do
+		[ -n "$value" ] || continue
+		uci add_list "${key}=${value}" || return 1
+	done
+	NORDVPN_EASY_UCI_CHANGED=1
+}
+
+nordvpn_easy_repair_wireguard_interface_base_settings() {
+	local dns_values=''
+
+	# Read by actions.sh after base interface settings are repaired.
+	# shellcheck disable=SC2034
+	NORDVPN_EASY_UCI_CHANGED=0
+
+	[ -n "${VPN_ADDR:-}" ] || {
+		nordvpn_easy_log_blocker "${LOG_PHASE:-runtime}" "VPN address is missing; cannot repair WireGuard interface $VPN_IF"
+		return 1
+	}
+
+	nordvpn_easy_set_uci_option_if_changed "network.${VPN_IF}.proto" 'wireguard' || return 1
+	nordvpn_easy_set_uci_list_if_changed "network.${VPN_IF}.addresses" "$VPN_ADDR" || return 1
+
+	if ! uci -q get "network.${VPN_IF}.private_key" >/dev/null 2>&1; then
+		nordvpn_easy_log_blocker "${LOG_PHASE:-runtime}" "WireGuard interface $VPN_IF is missing its private key; full setup is required"
+		return 1
+	fi
+
+	if [ -n "${VPN_DNS1:-}" ] || [ -n "${VPN_DNS2:-}" ]; then
+		nordvpn_easy_set_uci_option_if_changed "network.${VPN_IF}.peerdns" '0' || return 1
+		[ -n "${VPN_DNS1:-}" ] && dns_values="$VPN_DNS1"
+		[ -n "${VPN_DNS2:-}" ] && dns_values="${dns_values:+$dns_values }$VPN_DNS2"
+		# shellcheck disable=SC2086 # DNS values are normalized single-token IPs.
+		nordvpn_easy_set_uci_list_if_changed "network.${VPN_IF}.dns" $dns_values || return 1
+	else
+		nordvpn_easy_set_uci_option_if_changed "network.${VPN_IF}.peerdns" '1' || return 1
+		nordvpn_easy_delete_uci_option_if_present "network.${VPN_IF}.dns" || return 1
+	fi
+
+	nordvpn_easy_set_uci_option_if_changed "network.${VPN_IF}.delegate" '0' || return 1
+	nordvpn_easy_set_uci_option_if_changed "network.${VPN_IF}.force_link" '1' || return 1
+}
+
 nordvpn_easy_wireguard_keepalive_value() {
 	case "${WIREGUARD_PERSISTENT_KEEPALIVE:-15}" in
 		''|*[!0-9]*)

--- a/tests/nordvpn-easy/test-actions.sh
+++ b/tests/nordvpn-easy/test-actions.sh
@@ -101,6 +101,26 @@ nordvpn_easy_ping_interface() {
 	[ "$PING_COUNT" -gt "$PING_FAIL_UNTIL" ]
 }
 nordvpn_easy_ping_wan() { return 0; }
+CACHED_VPN_COUNTRY="$VPN_COUNTRY"
+VPN_COUNTRY=''
+CURL_CALL_COUNT=0
+# shellcheck disable=SC2317
+curl() {
+	CURL_CALL_COUNT=$((CURL_CALL_COUNT + 1))
+	printf '%s\n' 'curl: (28) Operation timed out' >&2
+	return 28
+}
+
+nordvpn_easy_get_servers_list || {
+	printf '%s\n' 'FAIL: server list refresh should fall back to the existing cache after API failure' >&2
+	exit 1
+}
+
+assert_eq '1' "$CURL_CALL_COUNT" 'server list refresh attempts API before cache fallback'
+assert_eq 'it123' "$(jq -r '.[0].station' "$SERVER_LIST_FILE")" 'server list cache is kept when API fails'
+unset -f curl 2>/dev/null || true
+VPN_COUNTRY="$CACHED_VPN_COUNTRY"
+
 nordvpn_easy_get_servers_list() { return 0; }
 nordvpn_easy_server_selection_is_manual() { [ "${SERVER_SELECTION_MODE:-auto}" = 'manual' ]; }
 nordvpn_easy_vpn_is_configured() { return "$VPN_CONFIGURED_RC"; }
@@ -355,6 +375,8 @@ BOOTSTRAP_REPAIR_RC=0
 BOOTSTRAP_REPAIR_COUNT=0
 BOOTSTRAP_CONFIGURE_COUNT=0
 BOOTSTRAP_ENABLE_COUNT=0
+BOOTSTRAP_BASE_COUNT=0
+BOOTSTRAP_BASE_CHANGED=0
 BOOTSTRAP_TRANSPORT_COUNT=0
 BOOTSTRAP_ZONE_COUNT=0
 BOOTSTRAP_PRESENT_COUNT=0
@@ -373,6 +395,11 @@ nordvpn_easy_configure_vpn_interface() {
 }
 nordvpn_easy_ensure_vpn_interface_enabled() {
 	BOOTSTRAP_ENABLE_COUNT=$((BOOTSTRAP_ENABLE_COUNT + 1))
+	return 0
+}
+nordvpn_easy_repair_wireguard_interface_base_settings() {
+	BOOTSTRAP_BASE_COUNT=$((BOOTSTRAP_BASE_COUNT + 1))
+	NORDVPN_EASY_UCI_CHANGED="$BOOTSTRAP_BASE_CHANGED"
 	return 0
 }
 nordvpn_easy_apply_wireguard_transport_settings() {
@@ -423,6 +450,8 @@ VPN_CONFIGURED_RC=0
 BOOTSTRAP_REPAIR_COUNT=0
 BOOTSTRAP_CONFIGURE_COUNT=0
 BOOTSTRAP_ENABLE_COUNT=0
+BOOTSTRAP_BASE_COUNT=0
+BOOTSTRAP_BASE_CHANGED=0
 BOOTSTRAP_TRANSPORT_COUNT=0
 BOOTSTRAP_ZONE_COUNT=0
 BOOTSTRAP_PRESENT_COUNT=0
@@ -434,6 +463,8 @@ nordvpn_easy_bootstrap_if_needed
 assert_eq '1' "$(cat "$NETWORK_RELOAD_COUNT_FILE")" 'bootstrap retries a pending network reload before skipping repair'
 assert_eq '0' "$BOOTSTRAP_REPAIR_COUNT" 'configured bootstrap does not run missing peer repair after pending reload retry'
 assert_eq '1' "$BOOTSTRAP_ENABLE_COUNT" 'configured bootstrap continues after pending reload retry'
+assert_eq '1' "$BOOTSTRAP_BASE_COUNT" 'configured bootstrap repairs base WireGuard interface settings'
+assert_eq '1' "$BOOTSTRAP_TRANSPORT_COUNT" 'configured bootstrap repairs WireGuard transport settings'
 if [ -f "$(nordvpn_easy_pending_network_reload_marker_path)" ]; then
 	printf '%s\n' 'FAIL: successful pending reload retry should clear marker' >&2
 	exit 1

--- a/tests/nordvpn-easy/test-common-temp.sh
+++ b/tests/nordvpn-easy/test-common-temp.sh
@@ -144,6 +144,18 @@ uci() {
 		'get network.wg0.private_key')
 			printf '%s\n' 'private-secret'
 			;;
+		'get network.wg0.addresses')
+			printf '%s\n' '10.5.0.2/32'
+			;;
+		'get network.wg0.peerdns')
+			printf '%s\n' '0'
+			;;
+		'get network.wg0.delegate')
+			printf '%s\n' '0'
+			;;
+		'get network.wg0.force_link')
+			printf '%s\n' '1'
+			;;
 		'get network.wg0server.endpoint_host')
 			printf '%s\n' 'it12.nordvpn.com'
 			;;
@@ -189,6 +201,20 @@ logread() {
 
 DIAGNOSTICS_OUTPUT="$(nordvpn_easy_export_diagnostics_log 'nordvpn-easy')"
 
+assert_diagnostics_contains() {
+	needle="$1"
+	message="$2"
+
+	case "$DIAGNOSTICS_OUTPUT" in
+		*"$needle"*)
+			;;
+		*)
+			printf '%s\n' "$message" >&2
+			exit 1
+			;;
+	esac
+}
+
 case "$DIAGNOSTICS_OUTPUT" in
 	*'WireGuard status'*'persistent_keepalive'*'mtu_fix'*)
 		;;
@@ -198,14 +224,12 @@ case "$DIAGNOSTICS_OUTPUT" in
 		;;
 esac
 
-case "$DIAGNOSTICS_OUTPUT" in
-	*'Health summary'*'convention_peer_section=wg0server'*'peer_section_found=yes'*'required_peer_keys_missing=none'*'probable_issue=none detected'*)
-		;;
-	*)
-		printf '%s\n' 'FAIL: diagnostics export should include a useful health summary' >&2
-		exit 1
-		;;
-esac
+assert_diagnostics_contains 'Health summary' 'FAIL: diagnostics export should include a useful health summary'
+assert_diagnostics_contains 'convention_peer_section=wg0server' 'FAIL: diagnostics export should include a useful health summary'
+assert_diagnostics_contains 'peer_section_found=yes' 'FAIL: diagnostics export should include a useful health summary'
+assert_diagnostics_contains 'required_interface_keys_missing=none' 'FAIL: diagnostics export should include a useful health summary'
+assert_diagnostics_contains 'required_peer_keys_missing=none' 'FAIL: diagnostics export should include a useful health summary'
+assert_diagnostics_contains 'probable_issue=none detected' 'FAIL: diagnostics export should include a useful health summary'
 
 case "$DIAGNOSTICS_OUTPUT" in
 	*token-secret*|*private-secret*)

--- a/tests/nordvpn-easy/test-package-lockstep.sh
+++ b/tests/nordvpn-easy/test-package-lockstep.sh
@@ -37,6 +37,7 @@ luci_init_source="\$(CURDIR)/../nordvpn-easy/files/etc/init.d/nordvpn-easy"
 luci_core_source="\$(CURDIR)/../nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh"
 luci_lib_source="\$(CURDIR)/../nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/."
 luci_rpcd_source="\$(CURDIR)/../nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy"
+config_cleanup='rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg'
 
 assert_eq "$backend_version" "$luci_version" 'backend and LuCI packages share default version'
 assert_eq "$backend_release" "$luci_release" 'backend and LuCI packages share default release'
@@ -64,6 +65,16 @@ grep -E "${dollar_pattern}${dollar_pattern}+lib" "$LUCI_MAKEFILE" >/dev/null 2>&
 
 grep -F "$luci_rpcd_source" "$LUCI_MAKEFILE" >/dev/null 2>&1 || {
 	printf '%s\n' 'FAIL: LuCI package must install rpcd plugin from backend package source' >&2
+	exit 1
+}
+
+grep -F "$config_cleanup" "$BACKEND_MAKEFILE" >/dev/null 2>&1 || {
+	printf '%s\n' 'FAIL: backend package prerm must remove the UCI config during uninstall' >&2
+	exit 1
+}
+
+grep -F "$config_cleanup" "$LUCI_MAKEFILE" >/dev/null 2>&1 || {
+	printf '%s\n' 'FAIL: LuCI package prerm must remove the UCI config during uninstall' >&2
 	exit 1
 }
 

--- a/tests/nordvpn-easy/test-package-lockstep.sh
+++ b/tests/nordvpn-easy/test-package-lockstep.sh
@@ -5,9 +5,11 @@ set -eu
 ROOT_DIR="$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)"
 BACKEND_MAKEFILE="$ROOT_DIR/openwrt-packages/nordvpn-easy/Makefile"
 LUCI_MAKEFILE="$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/Makefile"
+RELEASE_WORKFLOW="$ROOT_DIR/.github/workflows/release.yml"
 SCHEMA_LIB="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/schema.sh"
 CORE_SCRIPT="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh"
 INIT_SCRIPT="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy"
+RPCD_SCRIPT="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy"
 
 assert_eq() {
 	expected="$1"
@@ -37,10 +39,33 @@ luci_init_source="\$(CURDIR)/../nordvpn-easy/files/etc/init.d/nordvpn-easy"
 luci_core_source="\$(CURDIR)/../nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh"
 luci_lib_source="\$(CURDIR)/../nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/."
 luci_rpcd_source="\$(CURDIR)/../nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy"
+backend_rpcd_install="\$(INSTALL_BIN) ./files/usr/libexec/rpcd/nordvpn.easy \$(1)/usr/libexec/rpcd/nordvpn.easy"
+release_preplace_lib="\${BACKEND_FILES}/usr/libexec/nordvpn-easy/lib/."
+release_preplace_rpcd="\${BACKEND_FILES}/usr/libexec/rpcd/nordvpn.easy"
+release_apk_rpcd="\${VERIFY_DIR}/usr/libexec/rpcd/nordvpn.easy"
+release_ipk_rpcd="\${VERIFY_DIR}/data/usr/libexec/rpcd/nordvpn.easy"
+release_apk_config_context="\${VERIFY_DIR}/usr/libexec/nordvpn-easy/lib/config-context.sh"
+release_ipk_config_context="\${VERIFY_DIR}/data/usr/libexec/nordvpn-easy/lib/config-context.sh"
+release_apk_runtime="\${VERIFY_DIR}/usr/libexec/nordvpn-easy/lib/runtime.sh"
+release_ipk_runtime="\${VERIFY_DIR}/data/usr/libexec/nordvpn-easy/lib/runtime.sh"
+release_apk_postrm='post-deinstall: |'
+release_ipk_postrm="\${VERIFY_DIR}/control/postrm"
 config_cleanup='rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg'
+backend_postrm='define Package/nordvpn-easy/postrm'
+luci_postrm="define Package/\$(PKG_NAME)/postrm"
 
 assert_eq "$backend_version" "$luci_version" 'backend and LuCI packages share default version'
 assert_eq "$backend_release" "$luci_release" 'backend and LuCI packages share default release'
+
+[ -f "$RPCD_SCRIPT" ] || {
+	printf '%s\n' 'FAIL: backend rpcd plugin must exist in package source' >&2
+	exit 1
+}
+
+[ -x "$RPCD_SCRIPT" ] || {
+	printf '%s\n' 'FAIL: backend rpcd plugin must be executable in package source' >&2
+	exit 1
+}
 
 grep -F "$luci_init_source" "$LUCI_MAKEFILE" >/dev/null 2>&1 || {
 	printf '%s\n' 'FAIL: LuCI package must install init script from backend package source' >&2
@@ -68,13 +93,57 @@ grep -F "$luci_rpcd_source" "$LUCI_MAKEFILE" >/dev/null 2>&1 || {
 	exit 1
 }
 
-grep -F "$config_cleanup" "$BACKEND_MAKEFILE" >/dev/null 2>&1 || {
-	printf '%s\n' 'FAIL: backend package prerm must remove the UCI config during uninstall' >&2
+grep -F "$backend_rpcd_install" "$BACKEND_MAKEFILE" >/dev/null 2>&1 || {
+	printf '%s\n' 'FAIL: backend package must install rpcd plugin with executable permissions' >&2
 	exit 1
 }
 
-grep -F "$config_cleanup" "$LUCI_MAKEFILE" >/dev/null 2>&1 || {
-	printf '%s\n' 'FAIL: LuCI package prerm must remove the UCI config during uninstall' >&2
+grep -F "$release_preplace_lib" "$RELEASE_WORKFLOW" >/dev/null 2>&1 || {
+	printf '%s\n' 'FAIL: OPKG compatibility pre-place must copy backend library directory' >&2
+	exit 1
+}
+
+grep -F "$release_preplace_rpcd" "$RELEASE_WORKFLOW" >/dev/null 2>&1 || {
+	printf '%s\n' 'FAIL: OPKG compatibility pre-place must copy rpcd plugin' >&2
+	exit 1
+}
+
+for release_payload in \
+	"$release_apk_rpcd" \
+	"$release_ipk_rpcd" \
+	"$release_apk_config_context" \
+	"$release_ipk_config_context" \
+	"$release_apk_runtime" \
+	"$release_ipk_runtime" \
+	"$release_apk_postrm" \
+	"$release_ipk_postrm"
+do
+	grep -F "$release_payload" "$RELEASE_WORKFLOW" >/dev/null 2>&1 || {
+		printf '%s\n' "FAIL: release workflow must verify payload file: $release_payload" >&2
+		exit 1
+	}
+done
+
+backend_cleanup_count="$(grep -F -c "$config_cleanup" "$BACKEND_MAKEFILE" || true)"
+luci_cleanup_count="$(grep -F -c "$config_cleanup" "$LUCI_MAKEFILE" || true)"
+
+[ "$backend_cleanup_count" -ge 2 ] || {
+	printf '%s\n' 'FAIL: backend package must remove UCI config in both prerm and postrm' >&2
+	exit 1
+}
+
+[ "$luci_cleanup_count" -ge 2 ] || {
+	printf '%s\n' 'FAIL: LuCI package must remove UCI config in both prerm and postrm' >&2
+	exit 1
+}
+
+grep -F "$backend_postrm" "$BACKEND_MAKEFILE" >/dev/null 2>&1 || {
+	printf '%s\n' 'FAIL: backend package must define postrm cleanup for opkg-preserved conffiles' >&2
+	exit 1
+}
+
+grep -F "$luci_postrm" "$LUCI_MAKEFILE" >/dev/null 2>&1 || {
+	printf '%s\n' 'FAIL: LuCI package must define postrm cleanup for opkg-preserved conffiles' >&2
 	exit 1
 }
 

--- a/tests/nordvpn-easy/test-package-lockstep.sh
+++ b/tests/nordvpn-easy/test-package-lockstep.sh
@@ -51,8 +51,13 @@ release_ipk_runtime="\${VERIFY_DIR}/data/usr/libexec/nordvpn-easy/lib/runtime.sh
 release_apk_postrm='post-deinstall: |'
 release_ipk_postrm="\${VERIFY_DIR}/control/postrm"
 config_cleanup='rm -f /etc/config/nordvpn_easy /etc/config/nordvpn_easy-opkg'
+backend_prerm='define Package/nordvpn-easy/prerm'
 backend_postrm='define Package/nordvpn-easy/postrm'
+luci_prerm="define Package/\$(PKG_NAME)/prerm"
 luci_postrm="define Package/\$(PKG_NAME)/postrm"
+backend_luci_presence_helper='luci_app_installed()'
+backend_opkg_presence_check='opkg status luci-app-nordvpn-easy >/dev/null 2>&1'
+backend_apk_presence_check='apk info -e luci-app-nordvpn-easy >/dev/null 2>&1'
 
 assert_eq "$backend_version" "$luci_version" 'backend and LuCI packages share default version'
 assert_eq "$backend_release" "$luci_release" 'backend and LuCI packages share default release'
@@ -127,18 +132,36 @@ done
 backend_cleanup_count="$(grep -F -c "$config_cleanup" "$BACKEND_MAKEFILE" || true)"
 luci_cleanup_count="$(grep -F -c "$config_cleanup" "$LUCI_MAKEFILE" || true)"
 
-[ "$backend_cleanup_count" -ge 2 ] || {
-	printf '%s\n' 'FAIL: backend package must remove UCI config in both prerm and postrm' >&2
+assert_eq '1' "$backend_cleanup_count" 'backend package must remove UCI config from a single uninstall hook'
+assert_eq '1' "$luci_cleanup_count" 'LuCI package must remove UCI config from a single uninstall hook'
+
+grep -F "$backend_prerm" "$BACKEND_MAKEFILE" >/dev/null 2>&1 && {
+	printf '%s\n' 'FAIL: backend package must not remove UCI config from prerm' >&2
 	exit 1
 }
 
-[ "$luci_cleanup_count" -ge 2 ] || {
-	printf '%s\n' 'FAIL: LuCI package must remove UCI config in both prerm and postrm' >&2
+grep -F "$luci_prerm" "$LUCI_MAKEFILE" >/dev/null 2>&1 && {
+	printf '%s\n' 'FAIL: LuCI package must not remove UCI config from prerm' >&2
 	exit 1
 }
 
 grep -F "$backend_postrm" "$BACKEND_MAKEFILE" >/dev/null 2>&1 || {
 	printf '%s\n' 'FAIL: backend package must define postrm cleanup for opkg-preserved conffiles' >&2
+	exit 1
+}
+
+grep -F "$backend_luci_presence_helper" "$BACKEND_MAKEFILE" >/dev/null 2>&1 || {
+	printf '%s\n' 'FAIL: backend postrm must define a shared-package presence helper' >&2
+	exit 1
+}
+
+grep -F "$backend_opkg_presence_check" "$BACKEND_MAKEFILE" >/dev/null 2>&1 || {
+	printf '%s\n' 'FAIL: backend postrm must keep shared UCI config while luci-app-nordvpn-easy is installed' >&2
+	exit 1
+}
+
+grep -F "$backend_apk_presence_check" "$BACKEND_MAKEFILE" >/dev/null 2>&1 || {
+	printf '%s\n' 'FAIL: backend postrm must support APK package presence checks' >&2
 	exit 1
 }
 

--- a/tests/nordvpn-easy/test-rpcd.sh
+++ b/tests/nordvpn-easy/test-rpcd.sh
@@ -32,6 +32,47 @@ printf '%s' "$UNKNOWN_JSON" | jq -er '
 	.message == "unknown method: unknown"
 ' >/dev/null
 
+REFRESH_INIT="$TMP_DIR/init-refresh"
+REFRESH_CAPTURE="$TMP_DIR/refresh-calls"
+cat > "$REFRESH_INIT" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$REFRESH_CAPTURE"
+exit 0
+EOF
+chmod 755 "$REFRESH_INIT"
+
+REFRESH_FORCE_JSON="$(
+	printf '{"force":true}' |
+		NORDVPN_EASY_LIB_DIR="$LIB_DIR" \
+		NORDVPN_EASY_INIT_SCRIPT="$REFRESH_INIT" \
+		sh "$RPCD_SCRIPT" call refresh_countries
+)"
+printf '%s' "$REFRESH_FORCE_JSON" | jq -er '
+	.success == true and
+	.action == "refresh_countries_force"
+' >/dev/null
+assert_refresh_call="$(tail -n 1 "$REFRESH_CAPTURE")"
+[ "$assert_refresh_call" = 'refresh_countries_force' ] || {
+	printf '%s\n' 'FAIL: rpc refresh_countries force=true should invoke refresh_countries_force' >&2
+	exit 1
+}
+
+REFRESH_DEFAULT_JSON="$(
+	printf '{}' |
+		NORDVPN_EASY_LIB_DIR="$LIB_DIR" \
+		NORDVPN_EASY_INIT_SCRIPT="$REFRESH_INIT" \
+		sh "$RPCD_SCRIPT" call refresh_countries
+)"
+printf '%s' "$REFRESH_DEFAULT_JSON" | jq -er '
+	.success == true and
+	.action == "refresh_countries"
+' >/dev/null
+assert_refresh_call="$(tail -n 1 "$REFRESH_CAPTURE")"
+[ "$assert_refresh_call" = 'refresh_countries' ] || {
+	printf '%s\n' 'FAIL: rpc refresh_countries default should invoke refresh_countries' >&2
+	exit 1
+}
+
 FAKE_INIT="$TMP_DIR/init"
 RUN_DIR="$TMP_DIR/run"
 mkdir -p "$RUN_DIR"

--- a/tests/nordvpn-easy/test-runtime.sh
+++ b/tests/nordvpn-easy/test-runtime.sh
@@ -177,4 +177,9 @@ STATUS_JSON_MISSING_STATION="$(nordvpn_easy_emit_status_json)"
 
 assert_eq '' "$(printf '%s' "$STATUS_JSON_MISSING_STATION" | jq -r '.current_server_station')" 'status json does not expose endpoint hostname as station when station metadata is missing'
 
+DIAG_SUMMARY="$(nordvpn_easy_print_diagnostics_health_summary wg0)"
+
+assert_eq 'private_key,addresses,peerdns,delegate,force_link' "$(printf '%s\n' "$DIAG_SUMMARY" | sed -n 's/^required_interface_keys_missing=//p')" 'diagnostics report incomplete WireGuard interface keys separately'
+assert_eq 'wireguard interface is incomplete (private_key,addresses,peerdns,delegate,force_link)' "$(printf '%s\n' "$DIAG_SUMMARY" | sed -n 's/^probable_issue=//p')" 'diagnostics prioritize incomplete interface before runtime peer symptoms'
+
 printf '%s\n' 'test-runtime.sh: ok'

--- a/tests/nordvpn-easy/test-service.js
+++ b/tests/nordvpn-easy/test-service.js
@@ -49,13 +49,18 @@ function loadServiceModule() {
 				declare(spec) {
 					return function() {
 						const args = Array.prototype.slice.call(arguments);
-						calls.push({ spec: spec, args: args });
-						return Promise.resolve(responses.length ? responses.shift() : {
+						const response = responses.length ? responses.shift() : {
 							code: 0,
 							success: true,
 							stdout: JSON.stringify({ method: spec.method, args: args }),
 							stderr: ''
-					});
+						};
+
+						calls.push({ spec: spec, args: args });
+						if (response instanceof Error)
+							return Promise.reject(response);
+
+						return Promise.resolve(response);
 				};
 			}
 		},
@@ -127,6 +132,16 @@ Promise.resolve().then(async function() {
 	assert.equal(busyResult.skipped, true, 'busy result preserves skipped flag');
 	assert.equal(busyResult.holder_action, 'setup', 'busy result preserves lock holder action');
 	assert.match(busyError.message, /already running setup/, 'busy result renders an operation-in-progress error');
+
+	const missingRpc = loadServiceModule();
+	missingRpc.responses.push(
+		new Error('RPC call to nordvpn.easy/refresh_countries failed with error -32000: Object not found')
+	);
+	await assert.rejects(
+		missingRpc.service.execService('refresh_countries_force'),
+		/backend RPC object is not registered/,
+		'missing rpcd object renders an actionable backend registration error'
+	);
 
 	await assert.rejects(
 		loaded.service.execService('unsupported_action'),

--- a/tests/nordvpn-easy/test-wireguard.sh
+++ b/tests/nordvpn-easy/test-wireguard.sh
@@ -41,6 +41,12 @@ UCI_KEEPALIVE=''
 UCI_MTU=''
 UCI_STATION=''
 UCI_HOSTNAME=''
+UCI_PRIVATE_KEY=''
+UCI_ADDRESSES=''
+UCI_PEERDNS=''
+UCI_DNS=''
+UCI_DELEGATE=''
+UCI_FORCE_LINK=''
 
 uci() {
 	case "$1" in
@@ -52,6 +58,12 @@ uci() {
 		get)
 				case "$2" in
 					network.wg0.proto) [ -n "$UCI_PROTO" ] || return 1; printf '%s\n' "$UCI_PROTO" ;;
+					network.wg0.private_key) [ -n "$UCI_PRIVATE_KEY" ] || return 1; printf '%s\n' "$UCI_PRIVATE_KEY" ;;
+					network.wg0.addresses) [ -n "$UCI_ADDRESSES" ] || return 1; printf '%s\n' "$UCI_ADDRESSES" ;;
+					network.wg0.peerdns) [ -n "$UCI_PEERDNS" ] || return 1; printf '%s\n' "$UCI_PEERDNS" ;;
+					network.wg0.dns) [ -n "$UCI_DNS" ] || return 1; printf '%s\n' "$UCI_DNS" ;;
+					network.wg0.delegate) [ -n "$UCI_DELEGATE" ] || return 1; printf '%s\n' "$UCI_DELEGATE" ;;
+					network.wg0.force_link) [ -n "$UCI_FORCE_LINK" ] || return 1; printf '%s\n' "$UCI_FORCE_LINK" ;;
 					network.wg0server.endpoint_host) [ -n "$UCI_ENDPOINT_HOST" ] || return 1; printf '%s\n' "$UCI_ENDPOINT_HOST" ;;
 					network.wg0server.endpoint_port) printf '%s\n' "$UCI_ENDPOINT_PORT" ;;
 					network.wg0server.persistent_keepalive) printf '%s\n' "$UCI_KEEPALIVE" ;;
@@ -76,6 +88,11 @@ uci() {
 				;;
 			set)
 				case "${2%%=*}" in
+					network.wg0.proto) UCI_PROTO="${2#*=}" ;;
+					network.wg0.private_key) UCI_PRIVATE_KEY="${2#*=}" ;;
+					network.wg0.peerdns) UCI_PEERDNS="${2#*=}" ;;
+					network.wg0.delegate) UCI_DELEGATE="${2#*=}" ;;
+					network.wg0.force_link) UCI_FORCE_LINK="${2#*=}" ;;
 					network.wg0server) UCI_PEER_SECTION=1 ;;
 					network.wg0server.endpoint_host) UCI_ENDPOINT_HOST="${2#*=}" ;;
 					network.wg0server.endpoint_port) UCI_ENDPOINT_PORT="${2#*=}" ;;
@@ -86,8 +103,21 @@ uci() {
 				esac
 				return 0
 				;;
+			add_list)
+				case "${2%%=*}" in
+					network.wg0.addresses)
+						UCI_ADDRESSES="${UCI_ADDRESSES:+$UCI_ADDRESSES }${2#*=}"
+						;;
+					network.wg0.dns)
+						UCI_DNS="${UCI_DNS:+$UCI_DNS }${2#*=}"
+						;;
+				esac
+				return 0
+				;;
 			delete)
 				case "$2" in
+					network.wg0.addresses) UCI_ADDRESSES='' ;;
+					network.wg0.dns) UCI_DNS='' ;;
 					network.wg0.mtu) UCI_MTU='' ;;
 				esac
 				return 0
@@ -129,6 +159,9 @@ VPN_IF='wg0'
 VPN_PORT='51820'
 WIREGUARD_PERSISTENT_KEEPALIVE='15'
 WIREGUARD_MTU=''
+VPN_ADDR='10.5.0.2/32'
+VPN_DNS1='103.86.99.99'
+VPN_DNS2='103.86.96.96'
 POST_RESTART_DELAY='5'
 
 UCI_PROTO='wireguard'
@@ -190,5 +223,27 @@ assert_eq '443' "$UCI_ENDPOINT_PORT" 'transport repair applies explicit endpoint
 WIREGUARD_MTU=''
 nordvpn_easy_apply_wireguard_transport_settings 'wg0server'
 assert_eq '' "$UCI_MTU" 'transport repair removes MTU when automatic is selected'
+
+UCI_PRIVATE_KEY='PRIVATE'
+UCI_ADDRESSES=''
+UCI_PEERDNS=''
+UCI_DNS='1.1.1.1'
+UCI_DELEGATE=''
+UCI_FORCE_LINK=''
+NORDVPN_EASY_UCI_CHANGED=0
+
+nordvpn_easy_repair_wireguard_interface_base_settings
+
+assert_eq '1' "$NORDVPN_EASY_UCI_CHANGED" 'base interface repair reports changed UCI'
+assert_eq 'wireguard' "$UCI_PROTO" 'base interface repair preserves WireGuard proto'
+assert_eq '10.5.0.2/32' "$UCI_ADDRESSES" 'base interface repair restores configured address'
+assert_eq '0' "$UCI_PEERDNS" 'base interface repair disables peer DNS when NordVPN DNS is configured'
+assert_eq '103.86.99.99 103.86.96.96' "$UCI_DNS" 'base interface repair replaces stale DNS list'
+assert_eq '0' "$UCI_DELEGATE" 'base interface repair disables IPv6 delegation'
+assert_eq '1' "$UCI_FORCE_LINK" 'base interface repair forces link creation'
+
+nordvpn_easy_repair_wireguard_interface_base_settings
+
+assert_eq '0' "$NORDVPN_EASY_UCI_CHANGED" 'base interface repair is idempotent once settings match'
 
 printf '%s\n' 'test-wireguard.sh: ok'


### PR DESCRIPTION
- **Remove config file with during app uninstallation**
- **fix: harden NordVPN Easy rpcd packaging and cleanup**
- **Harden NordVPN Easy packaging, RPCD, diagnostics and WireGuard recovery**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WireGuard interface configuration validation and automatic repair capabilities

* **Bug Fixes**
  * Server and country list caching now automatically falls back when downloads fail
  * Package configuration files properly removed during uninstall and upgrades
  * Missing WireGuard interface keys now detected and reported in diagnostics

* **Improvements**
  * Enhanced error messages guide users to reinstall/upgrade when backend issues occur
  * Expanded diagnostics reporting to identify incomplete configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tis24dev/NordVPN-Easy-OpenWrt/pull/59)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->