### PR TITLE
Fix LuCI activation flow and page load latency

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
@@ -795,14 +795,17 @@ function handleSaveApply(viewState, state, ev, mode) {
 							updateLocalStatus(state, { force: true });
 							updatePublicIp(state, { force: true });
 						});
-					}).catch(function(err) {
-						const message = (err && err.message) ? err.message : String(err);
+						}).catch(function(err) {
+							const message = (err && err.message) ? err.message : String(err);
 
-						managerStore.setError(state, err);
-						managerStore.resumePolling(state);
-						service.notifyError(new Error(_('Automatic runtime sync failed: ') + message));
-						finishReject(err);
-					});
+							managerStore.setError(state, err);
+							state.pendingOperationLabel = '';
+							managerStore.resumePolling(state);
+							updateLocalStatus(state, { force: true });
+							updatePublicIp(state, { force: true });
+							service.notifyError(new Error(_('Automatic runtime sync failed: ') + message));
+							finishReject(err);
+						});
 				};
 
 				timeoutId = setTimeout(function() {

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global baseclass, managerData, managerFormat, managerStore, managerUI, service, ui, uci, document, setTimeout, clearTimeout, E, _ */
+/* global baseclass, managerData, managerFormat, managerStore, managerUI, service, ui, uci, setTimeout, clearTimeout, E, _ */
 'require baseclass';
 'require nordvpn-easy/manager-data as managerData';
 'require nordvpn-easy/manager-format as managerFormat';
@@ -693,16 +693,12 @@ function handleSaveApply(viewState, state, ev, mode) {
 			let settled = false;
 			let timeoutId = null;
 
-			const cleanup = function() {
-				if (timeoutId !== null) {
-					clearTimeout(timeoutId);
-					timeoutId = null;
-				}
-				if (viewState._uciAppliedHandler) {
-					document.removeEventListener('uci-applied', viewState._uciAppliedHandler);
-					viewState._uciAppliedHandler = null;
-				}
-			};
+				const cleanup = function() {
+					if (timeoutId !== null) {
+						clearTimeout(timeoutId);
+						timeoutId = null;
+					}
+				};
 
 			const finishResolve = function(value) {
 				if (settled)
@@ -733,8 +729,8 @@ function handleSaveApply(viewState, state, ev, mode) {
 			cleanup();
 
 			Promise.resolve(viewState.handleSave(ev)).then(function() {
-				viewState._uciAppliedHandler = function() {
-					Promise.resolve().then(function() {
+				const continueAfterUciApply = function() {
+					return Promise.resolve().then(function() {
 						uci.unload('nordvpn_easy');
 						return uci.load('nordvpn_easy');
 					}).then(function() {
@@ -819,12 +815,11 @@ function handleSaveApply(viewState, state, ev, mode) {
 					finishReject(timeoutError);
 				}, 60000);
 
-				document.addEventListener('uci-applied', viewState._uciAppliedHandler);
 				state.pendingOperationLabel = _('configuration');
 				state.currentOperationStatus = 'busy:configuration';
 				managerStore.setPhase(state, managerStore.PHASES.SAVING);
 				updateLocalStatus(state, { force: true });
-				Promise.resolve(ui.changes.apply(mode === '0')).catch(function(err) {
+				Promise.resolve(ui.changes.apply(mode === '0')).then(continueAfterUciApply).catch(function(err) {
 					managerStore.setError(state, err);
 					state.pendingOperationLabel = '';
 					managerStore.resumePolling(state);

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -26,8 +26,25 @@ function statusPayloadIsBusy(payload) {
 		String(status.operation_lock_state || 'none') === 'held';
 }
 
-function countriesCacheHasEntries(countriesRaw) {
-	return managerData.parseCountries(countriesRaw).length > 0;
+function refreshCountriesInBackground(selectEl, currentCountry) {
+	if (!selectEl)
+		return Promise.resolve();
+
+	return service.execService('refresh_countries').then(function(res) {
+		if (!res || res.code !== 0)
+			return null;
+
+		return fs.read(COUNTRIES_CACHE_PATH);
+	}).then(function(countriesRaw) {
+		if (countriesRaw == null)
+			return;
+
+		managerUI.renderCountryChoices(
+			selectEl,
+			managerData.parseCountries(countriesRaw),
+			managerData.normalizeCountryCode(currentCountry || selectEl.value || '')
+		);
+	}).catch(function() {});
 }
 
 const CountrySelectValue = form.ListValue.extend({
@@ -195,21 +212,13 @@ return view.extend({
 			const statusResult = results[2];
 			const statusPayload = service.parseExecJsonResponse(statusResult, null);
 			const runtimeBusy = statusPayloadIsBusy(statusPayload);
-			const countriesReady = (!countriesCacheHasEntries(countriesRaw) && !runtimeBusy)
-				? L.resolveDefault(service.execService('refresh_countries'), null).then(function() {
-					return L.resolveDefault(fs.read(COUNTRIES_CACHE_PATH), countriesRaw);
-				})
-				: Promise.resolve(countriesRaw);
+			const configuredCountry = managerData.normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
+			const currentMode = String(uci.get('nordvpn_easy', 'main', 'server_selection_mode') || 'auto');
+			const catalogPromise = managerStore.shouldLoadCatalog(currentMode, configuredCountry) && !runtimeBusy
+				? L.resolveDefault(service.execService('server_catalog', [ configuredCountry ]), null)
+				: Promise.resolve(null);
 
-			return countriesReady.then(function(finalCountriesRaw) {
-				const configuredCountry = managerData.normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
-				const currentMode = String(uci.get('nordvpn_easy', 'main', 'server_selection_mode') || 'auto');
-				const catalogPromise = managerStore.shouldLoadCatalog(currentMode, configuredCountry) && !runtimeBusy
-					? L.resolveDefault(service.execService('server_catalog', [ configuredCountry ]), null)
-					: Promise.resolve(null);
-	
-				return Promise.all([ Promise.resolve(finalCountriesRaw), Promise.resolve(statusResult), catalogPromise ]);
-			});
+			return Promise.all([ Promise.resolve(countriesRaw), Promise.resolve(statusResult), catalogPromise ]);
 		});
 	},
 
@@ -323,6 +332,9 @@ return view.extend({
 
 			managerUI.renderServerChoices(managerUI.getSelectElement(managerUI.ids.SERVER_FIELD_ID), state.currentServerCatalog, currentPreferredStation);
 			managerActions.renderLocalStatusSnapshot(state, state.currentLocalStatus);
+			if (!countries.length && !statusPayloadIsBusy(initialStatusPayload))
+				refreshCountriesInBackground(countrySelect, currentCountry);
+
 			if (!state.currentLocalStatusFresh)
 				managerActions.updateLocalStatus(state, { force: true });
 

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -661,6 +661,10 @@ verify_public_country_selection () {
     return 0
   }
 
+  nordvpn_easy_write_runtime_cache_value "$NORDVPN_EASY_PUBLIC_IP_CACHE" "${PUBLIC_IP:-}" >/dev/null 2>&1 || true
+  nordvpn_easy_write_runtime_cache_value "$NORDVPN_EASY_PUBLIC_COUNTRY_CACHE" "${PUBLIC_COUNTRY:-}" >/dev/null 2>&1 || true
+  nordvpn_easy_write_runtime_cache_value "$NORDVPN_EASY_LAST_ERROR_CACHE" '' >/dev/null 2>&1 || true
+
   if [ -z "$VPN_COUNTRY" ]; then
     log "Public IP verification: $PUBLIC_IP geolocates to $PUBLIC_COUNTRY with automatic country selection"
     return 0

--- a/tests/nordvpn-easy/test-config.js
+++ b/tests/nordvpn-easy/test-config.js
@@ -258,6 +258,7 @@ function loadConfigView(options) {
 		fsRead: [],
 		uciLoad: [],
 		renderServerChoices: [],
+		renderCountryChoices: [],
 		renderLocalStatusSnapshot: [],
 		updateLocalStatus: [],
 		updatePublicIp: [],
@@ -378,7 +379,13 @@ function loadConfigView(options) {
 			getInputElement() {
 				return null;
 			},
-			renderCountryChoices() {},
+			renderCountryChoices(selectEl, countries, currentCountry) {
+				calls.renderCountryChoices.push({
+					id: selectEl ? selectEl.id : '',
+					countries: normalizeValue(countries),
+					currentCountry: currentCountry
+				});
+			},
 			renderServerChoices(selectEl, catalog, currentStation) {
 				calls.renderServerChoices.push({
 					id: selectEl ? selectEl.id : '',
@@ -484,11 +491,10 @@ function loadConfigView(options) {
 	};
 }
 
-async function testLoadRefreshesCountriesAndLoadsManualCatalogWhenIdle() {
+async function testLoadUsesCachedCountriesAndLoadsManualCatalogWhenIdle() {
 	const harness = loadConfigView({
 		fsReadResponses: [
-			'[]',
-			JSON.stringify([ { name: 'Uruguay', code: 'UY' } ])
+			'[]'
 		],
 		uciValues: {
 			vpn_country: 'UY',
@@ -502,17 +508,16 @@ async function testLoadRefreshesCountriesAndLoadsManualCatalogWhenIdle() {
 	});
 	const data = await harness.view.load();
 
-	assert.equal(data[0], JSON.stringify([ { name: 'Uruguay', code: 'UY' } ]), 'empty country cache is refreshed before render data is returned');
+	assert.equal(data[0], '[]', 'empty country cache does not block initial render');
 	assert.deepEqual(
 		normalizeValue(harness.calls.service.map(function(call) {
 			return [ call.action, call.args ];
 		})),
 		[
 			[ 'status_json', [] ],
-			[ 'refresh_countries', [] ],
 			[ 'server_catalog', [ 'UY' ] ]
 		],
-		'idle manual configuration refreshes countries and loads the selected-country server catalog'
+		'idle manual configuration loads status and selected-country server catalog without blocking on country refresh'
 	);
 	assert.equal(data[2].code, 0, 'manual server catalog response is returned to render');
 }
@@ -625,10 +630,62 @@ async function testRenderWiresInitialStateAndLiveHandlers() {
 	assert.equal(harness.calls.onModeChanged, 1, 'mode select change delegates to manager-actions');
 }
 
+async function testRenderRefreshesEmptyCountryCacheInBackground() {
+	const statusResult = {
+		code: 0,
+		stdout: JSON.stringify({
+			desired_enabled: true,
+			runtime_disabled: false,
+			interface_disabled: false,
+			runtime_configured: false,
+			selected_country: '',
+			server_selection_mode: 'auto',
+			operation_status: 'idle'
+		}),
+		stderr: ''
+	};
+	const harness = loadConfigView({
+		fsReadResponses: [
+			JSON.stringify([ { name: 'Belize', code: 'BZ' } ])
+		],
+		uciValues: {
+			enabled: '1',
+			vpn_country: '',
+			server_selection_mode: 'auto',
+			preferred_server_station: ''
+		}
+	});
+
+	await harness.view.render([ '[]', statusResult, null ]);
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+
+	assert.deepEqual(
+		normalizeValue(harness.calls.service.map(function(call) {
+			return [ call.action, call.args ];
+		})),
+		[ [ 'refresh_countries', [] ] ],
+		'empty country cache refreshes in the background after render'
+	);
+	assert.deepEqual(
+		harness.calls.renderCountryChoices,
+		[
+			{
+				id: 'cbid.nordvpn_easy.main.vpn_country',
+				countries: [ { name: 'Belize', code: 'BZ' } ],
+				currentCountry: ''
+			}
+		],
+		'background country refresh repopulates the rendered country selector'
+	);
+}
+
 Promise.resolve().then(async function() {
-	await testLoadRefreshesCountriesAndLoadsManualCatalogWhenIdle();
+	await testLoadUsesCachedCountriesAndLoadsManualCatalogWhenIdle();
 	await testLoadSkipsRefreshesWhenRuntimeBusy();
 	await testRenderWiresInitialStateAndLiveHandlers();
+	await testRenderRefreshesEmptyCountryCacheInBackground();
 	console.log('test-config.js: ok');
 }).catch(function(err) {
 	console.error(err);

--- a/tests/nordvpn-easy/test-manager-actions.js
+++ b/tests/nordvpn-easy/test-manager-actions.js
@@ -994,10 +994,12 @@ function buildHandleSaveApplyHarness(options) {
 			changes: {
 				apply() {
 					calls.apply++;
-					Promise.resolve().then(function() {
-						if (uciAppliedHandler)
-							uciAppliedHandler();
-					});
+					if (opts.emitUciApplied !== false) {
+						Promise.resolve().then(function() {
+							if (uciAppliedHandler)
+								uciAppliedHandler();
+						});
+					}
 					return Promise.resolve();
 				}
 			}
@@ -1028,7 +1030,12 @@ function buildHandleSaveApplyHarness(options) {
 				if (name === 'uci-applied' && uciAppliedHandler === handler)
 					uciAppliedHandler = null;
 			}
-		}
+		},
+		setTimeout: opts.timeoutMs
+			? function(callback) {
+				return setTimeout(callback, opts.timeoutMs);
+			}
+			: setTimeout
 	}).managerActions;
 	const state = Object.assign({
 		pollingSuspended: false,
@@ -1138,6 +1145,28 @@ async function testHandleSaveApplyCancellationStopsRuntimeChange() {
 	assert.deepEqual(harness.pollingTransitions, [], 'cancelled confirmation leaves polling untouched');
 }
 
+async function testHandleSaveApplyContinuesWhenUciAppliedEventIsMissing() {
+	const harness = buildHandleSaveApplyHarness({
+		previousEnabled: false,
+		currentEnabled: true,
+		currentMode: 'auto',
+		currentCountry: '',
+		savedEnabled: '1',
+		savedCountry: '',
+		emitUciApplied: false,
+		timeoutMs: 25
+	});
+
+	await harness.actions.handleSaveApply(harness.viewState, harness.state, {}, '1');
+	await Promise.resolve();
+
+	assert.equal(harness.calls.handleSave, 1, 'enable flow saves the form once');
+	assert.equal(harness.calls.apply, 1, 'enable flow applies LuCI changes once');
+	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'connect' ] ], 'enable flow queues connect after apply promise resolves without uci-applied event');
+	assert.equal(harness.state.pendingOperationLabel, '', 'enable flow clears pending state after runtime completion without uci-applied event');
+	assert.equal(harness.pollingTransitions[harness.pollingTransitions.length - 1], 'resume', 'enable flow resumes polling without uci-applied event');
+}
+
 async function testHandleSaveApplyAutoModeClearsManualSelectionAndReconnects() {
 	const harness = buildHandleSaveApplyHarness({
 		previousEnabled: true,
@@ -1190,6 +1219,7 @@ Promise.resolve().then(async function() {
 	await testHandleSaveApplyRejectsManualModeWithoutCountry();
 	await testHandleSaveApplyRejectsManualModeWithoutCatalogServer();
 	await testHandleSaveApplyCancellationStopsRuntimeChange();
+	await testHandleSaveApplyContinuesWhenUciAppliedEventIsMissing();
 	await testHandleSaveApplyAutoModeClearsManualSelectionAndReconnects();
 	console.log('test-manager-actions.js: ok');
 }).catch(function(err) {

--- a/tests/nordvpn-easy/test-manager-actions.js
+++ b/tests/nordvpn-easy/test-manager-actions.js
@@ -1018,6 +1018,8 @@ function buildHandleSaveApplyHarness(options) {
 			},
 			load() {
 				calls.uciLoad++;
+				if (opts.uciLoadReject)
+					return Promise.reject(opts.uciLoadReject);
 				return Promise.resolve();
 			}
 		},
@@ -1167,6 +1169,32 @@ async function testHandleSaveApplyContinuesWhenUciAppliedEventIsMissing() {
 	assert.equal(harness.pollingTransitions[harness.pollingTransitions.length - 1], 'resume', 'enable flow resumes polling without uci-applied event');
 }
 
+async function testHandleSaveApplyClearsBusyStateWhenPostApplySyncFails() {
+	const syncError = new Error('uci reload failed');
+	const harness = buildHandleSaveApplyHarness({
+		previousEnabled: true,
+		currentEnabled: true,
+		currentMode: 'auto',
+		currentCountry: 'UY',
+		uciLoadReject: syncError,
+		timeoutMs: 25
+	});
+	let rejected = null;
+
+	await harness.actions.handleSaveApply(harness.viewState, harness.state, {}, '1').catch(function(err) {
+		rejected = err;
+	});
+	await Promise.resolve();
+	await Promise.resolve();
+
+	assert.equal(rejected, syncError, 'post-apply sync failure rejects with the original error');
+	assert.equal(harness.state.pendingOperationLabel, '', 'post-apply sync failure clears the applying label');
+	assert.equal(harness.pollingTransitions[harness.pollingTransitions.length - 1], 'resume', 'post-apply sync failure resumes polling');
+	assert.ok(harness.serviceCalls.indexOf('status_json') !== -1, 'post-apply sync failure refreshes local status');
+	assert.ok(harness.serviceCalls.indexOf('public_ip') !== -1, 'post-apply sync failure refreshes public IP state');
+	assert.match(harness.notifications[harness.notifications.length - 1].message, /Automatic runtime sync failed: uci reload failed/, 'post-apply sync failure reports a readable notification');
+}
+
 async function testHandleSaveApplyAutoModeClearsManualSelectionAndReconnects() {
 	const harness = buildHandleSaveApplyHarness({
 		previousEnabled: true,
@@ -1220,6 +1248,7 @@ Promise.resolve().then(async function() {
 	await testHandleSaveApplyRejectsManualModeWithoutCatalogServer();
 	await testHandleSaveApplyCancellationStopsRuntimeChange();
 	await testHandleSaveApplyContinuesWhenUciAppliedEventIsMissing();
+	await testHandleSaveApplyClearsBusyStateWhenPostApplySyncFails();
 	await testHandleSaveApplyAutoModeClearsManualSelectionAndReconnects();
 	console.log('test-manager-actions.js: ok');
 }).catch(function(err) {


### PR DESCRIPTION
Fix NordVPN Easy LuCI behavior after saving configuration.

The LuCI apply flow no longer depends on the fragile uci-applied browser event
before running backend runtime actions, so enabling or changing VPN settings now
continues with connect/reconnect/disconnect as expected.

Country refresh during page load is moved to a background update, preventing the
configuration page from blocking on slow NordVPN/API calls.

Also update runtime public IP/country cache during verification so the GUI does
not show stale country mismatch data after a successful connection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Country selection list now refreshes in the background, improving initial UI responsiveness.
  * Public IP geolocation results are cached, accelerating country detection performance.
  * Enhanced save/apply workflow for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tis24dev/NordVPN-Easy-OpenWrt/pull/60)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->