### PR TITLE
Fix config migration and runtime recovery

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
@@ -137,7 +137,7 @@ function deriveRuntimeActionPlan(previousEnabled, enabled, previousCountry, coun
 	}
 
 	if (runtimeReconciliationRequired) {
-		plan.actions = [ 'reconnect' ];
+		plan.actions = [ 'reconcile' ];
 		plan.successMessage = _('NordVPN Easy runtime synchronized with the saved configuration.');
 	}
 
@@ -590,6 +590,41 @@ function handleRefreshServerCatalog(state, ev) {
 	});
 }
 
+function loadSavedRuntimeConfig() {
+	return Promise.resolve().then(function() {
+		uci.unload('nordvpn_easy');
+		return uci.load('nordvpn_easy');
+	}).then(function() {
+		return {
+			enabled: managerData.parseEnabledFlag(uci.get('nordvpn_easy', 'main', 'enabled')),
+			country: managerData.normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || ''),
+			mode: String(uci.get('nordvpn_easy', 'main', 'server_selection_mode') || 'auto'),
+			preferredStation: String(uci.get('nordvpn_easy', 'main', 'preferred_server_station') || '')
+		};
+	});
+}
+
+function rememberSavedRuntimeConfig(viewState, state, savedConfig) {
+	viewState.initialEnabled = savedConfig.enabled;
+	viewState.initialCountry = savedConfig.country;
+	viewState.initialMode = savedConfig.mode;
+	viewState.initialPreferredStation = savedConfig.preferredStation;
+	state.appliedEnabled = savedConfig.enabled;
+	state.appliedCountryCode = savedConfig.country;
+}
+
+function refreshAfterSaveApply(state, refreshPublicIp) {
+	state.pendingOperationLabel = '';
+	managerStore.resumePolling(state);
+
+	return updateLocalStatus(state, { force: true }).then(function() {
+		if (refreshPublicIp)
+			return updatePublicIp(state, { force: true });
+
+		return null;
+	});
+}
+
 function handleSaveApply(viewState, state, ev, mode) {
 	const previousEnabled = !!viewState.initialEnabled;
 	const previousCountry = viewState.initialCountry || '';
@@ -691,7 +726,7 @@ function handleSaveApply(viewState, state, ev, mode) {
 
 		return new Promise(function(resolve, reject) {
 			let settled = false;
-			let timeoutId = null;
+				let timeoutId = null;
 
 				const cleanup = function() {
 					if (timeoutId !== null) {
@@ -730,82 +765,67 @@ function handleSaveApply(viewState, state, ev, mode) {
 
 			Promise.resolve(viewState.handleSave(ev)).then(function() {
 				const continueAfterUciApply = function() {
-					return Promise.resolve().then(function() {
-						uci.unload('nordvpn_easy');
-						return uci.load('nordvpn_easy');
-					}).then(function() {
-						const enabled = managerData.parseEnabledFlag(uci.get('nordvpn_easy', 'main', 'enabled'));
-						const country = managerData.normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
-						const modeValue = String(uci.get('nordvpn_easy', 'main', 'server_selection_mode') || 'auto');
-						const preferred = String(uci.get('nordvpn_easy', 'main', 'preferred_server_station') || '');
-						const localStatus = state.currentLocalStatusFresh ? state.currentLocalStatus : null;
-						const runtimePlan = deriveRuntimeActionPlan(
-							previousEnabled,
-							enabled,
-							previousCountry,
-							country,
-							previousMode,
-							modeValue,
-							previousPreferredStation,
-							preferred,
-							localStatus
-						);
-						const actions = runtimePlan.actions;
-						const successMessage = runtimePlan.successMessage;
+					return loadSavedRuntimeConfig().then(function(savedConfig) {
+						rememberSavedRuntimeConfig(viewState, state, savedConfig);
+						return updateLocalStatus(state, { force: true }).then(function(status) {
+							const localStatus = state.currentLocalStatusFresh ? status : null;
+							const runtimePlan = deriveRuntimeActionPlan(
+								previousEnabled,
+								savedConfig.enabled,
+								previousCountry,
+								savedConfig.country,
+								previousMode,
+								savedConfig.mode,
+								previousPreferredStation,
+								savedConfig.preferredStation,
+								localStatus
+							);
+							const actions = runtimePlan.actions;
+							const successMessage = runtimePlan.successMessage;
 
-						viewState.initialEnabled = enabled;
-						viewState.initialCountry = country;
-						viewState.initialMode = modeValue;
-						viewState.initialPreferredStation = preferred;
-						state.appliedEnabled = enabled;
-						state.appliedCountryCode = country;
+							if (!actions.length) {
+								notifyDebugBlock(_('Configuration applied'), [
+									_('UCI changes were saved successfully.'),
+									_('No runtime action was required.')
+								]);
+								return refreshAfterSaveApply(state, false).then(function() {
+									finishResolve();
+								});
+							}
 
-						if (!actions.length) {
-							notifyDebugBlock(_('Configuration applied'), [
-								_('UCI changes were saved successfully.'),
-								_('No runtime action was required.')
+							state.pendingOperationLabel = managerFormat.formatActionsLabel(actions);
+							state.currentOperationStatus = 'busy:' + state.pendingOperationLabel;
+							managerStore.setPhase(state, managerStore.PHASES.RUNTIME_BUSY);
+							managerStore.resumePolling(state);
+							notifyDebugBlock(_('Runtime actions queued'), [
+								_('Executing: %s').format(state.pendingOperationLabel),
+								_('Enabled state after save: %s').format(savedConfig.enabled ? _('checked') : _('unchecked'))
 							]);
-							state.pendingOperationLabel = '';
-							managerStore.resumePolling(state);
-							updateLocalStatus(state, { force: true });
-							finishResolve();
-							return Promise.resolve();
-						}
 
-						state.pendingOperationLabel = managerFormat.formatActionsLabel(actions);
-						state.currentOperationStatus = 'busy:' + state.pendingOperationLabel;
-						managerStore.setPhase(state, managerStore.PHASES.RUNTIME_BUSY);
-						managerStore.resumePolling(state);
-						notifyDebugBlock(_('Runtime actions queued'), [
-							_('Executing: %s').format(state.pendingOperationLabel),
-							_('Enabled state after save: %s').format(enabled ? _('checked') : _('unchecked'))
-						]);
-						updateLocalStatus(state, { force: true });
-
-						service.runActions(actions).then(function() {
-							service.notifyInfo(successMessage);
-							finishResolve();
-						}).catch(function(err) {
-							managerStore.setError(state, err);
-							service.notifyError(err);
-							finishReject(err);
-						}).finally(function() {
-							state.pendingOperationLabel = '';
-							managerStore.resumePolling(state);
-							updateLocalStatus(state, { force: true });
-							updatePublicIp(state, { force: true });
+							return updateLocalStatus(state, { force: true }).then(function() {
+								return service.runActions(actions);
+							}).then(function() {
+								service.notifyInfo(successMessage);
+								return refreshAfterSaveApply(state, true);
+							}).then(function() {
+								finishResolve();
+							}).catch(function(err) {
+								managerStore.setError(state, err);
+								service.notifyError(err);
+								return refreshAfterSaveApply(state, true).then(function() {
+									finishReject(err);
+								});
+							});
 						});
-						}).catch(function(err) {
-							const message = (err && err.message) ? err.message : String(err);
+					}).catch(function(err) {
+						const message = (err && err.message) ? err.message : String(err);
 
-							managerStore.setError(state, err);
-							state.pendingOperationLabel = '';
-							managerStore.resumePolling(state);
-							updateLocalStatus(state, { force: true });
-							updatePublicIp(state, { force: true });
+						managerStore.setError(state, err);
+						return refreshAfterSaveApply(state, true).then(function() {
 							service.notifyError(new Error(_('Automatic runtime sync failed: ') + message));
 							finishReject(err);
 						});
+					});
 				};
 
 				timeoutId = setTimeout(function() {

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/service.js
@@ -24,6 +24,11 @@ const callReconnect = rpc.declare({
 	method: 'reconnect'
 });
 
+const callReconcile = rpc.declare({
+	object: 'nordvpn.easy',
+	method: 'reconcile'
+});
+
 const callRotate = rpc.declare({
 	object: 'nordvpn.easy',
 	method: 'rotate'
@@ -199,6 +204,8 @@ function callSimpleAction(action) {
 		return callDisconnect();
 	case 'reconnect':
 		return callReconnect();
+	case 'reconcile':
+		return callReconcile();
 	case 'rotate':
 		return callRotate();
 	case 'setup':

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -201,26 +201,16 @@ const TokenValue = form.Value.extend({
 	}
 });
 
-return view.extend({
-	load: function() {
-		const uciLoad = uci.load('nordvpn_easy');
-		const countriesCachePromise = L.resolveDefault(fs.read(COUNTRIES_CACHE_PATH), '[]');
-		const statusPromise = L.resolveDefault(service.execService('status_json'), null);
-
-		return Promise.all([ uciLoad, countriesCachePromise, statusPromise ]).then(function(results) {
-			const countriesRaw = results[1];
-			const statusResult = results[2];
-			const statusPayload = service.parseExecJsonResponse(statusResult, null);
-			const runtimeBusy = statusPayloadIsBusy(statusPayload);
-			const configuredCountry = managerData.normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
-			const currentMode = String(uci.get('nordvpn_easy', 'main', 'server_selection_mode') || 'auto');
-			const catalogPromise = managerStore.shouldLoadCatalog(currentMode, configuredCountry) && !runtimeBusy
-				? L.resolveDefault(service.execService('server_catalog', [ configuredCountry ]), null)
-				: Promise.resolve(null);
-
-			return Promise.all([ Promise.resolve(countriesRaw), Promise.resolve(statusResult), catalogPromise ]);
-		});
-	},
+	return view.extend({
+		load: function() {
+			const uciLoad = uci.load('nordvpn_easy');
+			const countriesCachePromise = L.resolveDefault(fs.read(COUNTRIES_CACHE_PATH), '[]');
+			const statusPromise = L.resolveDefault(service.execService('status_json'), null);
+	
+			return Promise.all([ uciLoad, countriesCachePromise, statusPromise ]).then(function(results) {
+				return [ results[1], results[2], null ];
+			});
+		},
 
 	handleRefreshServerCatalog: function(ev) {
 		return managerActions.handleRefreshServerCatalog(state, ev);
@@ -334,6 +324,14 @@ return view.extend({
 			managerActions.renderLocalStatusSnapshot(state, state.currentLocalStatus);
 			if (!countries.length && !statusPayloadIsBusy(initialStatusPayload))
 				refreshCountriesInBackground(countrySelect, currentCountry);
+
+			if (!state.currentServerCatalog.servers.length &&
+				managerStore.shouldLoadCatalog(currentMode, currentCountry) &&
+				!statusPayloadIsBusy(initialStatusPayload)) {
+				managerActions.loadServerCatalog(state, currentCountry, false).catch(function(err) {
+					service.notifyError(err);
+				});
+			}
 
 			if (!state.currentLocalStatusFresh)
 				managerActions.updateLocalStatus(state, { force: true });

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -221,6 +221,8 @@ const TokenValue = form.Value.extend({
 		const initialStatusPayload = service.parseExecJsonResponse(data[1], null);
 		const initialStatusFresh = !!(initialStatusPayload && typeof initialStatusPayload === 'object' && !Array.isArray(initialStatusPayload));
 		const initialStatus = initialStatusFresh ? managerData.parseLocalStatus(JSON.stringify(initialStatusPayload)) : managerData.parseLocalStatus('{}');
+		// render keeps managerData.parseServerCatalog(data[2]) for external callers and
+		// testRenderWiresInitialStateAndLiveHandlers; load returns null in this slot.
 		const initialCatalog = managerData.parseServerCatalog(data[2] && data[2].code === 0 ? data[2].stdout || '{}' : '{}');
 		const currentCountry = managerData.normalizeCountryCode(uci.get('nordvpn_easy', 'main', 'vpn_country') || '');
 		const currentMode = String(uci.get('nordvpn_easy', 'main', 'server_selection_mode') || 'auto');

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -119,7 +119,7 @@ const CountrySelectValue = form.ListValue.extend({
 			}, [ _('Refresh Countries') ])
 		]);
 	}
-});
+	});
 
 const TokenValue = form.Value.extend({
 	storedValue: function(section_id) {
@@ -202,15 +202,15 @@ const TokenValue = form.Value.extend({
 });
 
 	return view.extend({
-		load: function() {
-			const uciLoad = uci.load('nordvpn_easy');
-			const countriesCachePromise = L.resolveDefault(fs.read(COUNTRIES_CACHE_PATH), '[]');
-			const statusPromise = L.resolveDefault(service.execService('status_json'), null);
-	
-			return Promise.all([ uciLoad, countriesCachePromise, statusPromise ]).then(function(results) {
-				return [ results[1], results[2], null ];
-			});
-		},
+	load: function() {
+		const uciLoad = uci.load('nordvpn_easy');
+		const countriesCachePromise = L.resolveDefault(fs.read(COUNTRIES_CACHE_PATH), '[]');
+		const statusPromise = L.resolveDefault(service.execService('status_json'), null);
+
+		return Promise.all([ uciLoad, countriesCachePromise, statusPromise ]).then(function(results) {
+			return [ results[1], results[2], null ];
+		});
+	},
 
 	handleRefreshServerCatalog: function(ev) {
 		return managerActions.handleRefreshServerCatalog(state, ev);
@@ -368,4 +368,4 @@ const TokenValue = form.Value.extend({
 	handleSaveApply: function(ev, mode) {
 		return managerActions.handleSaveApply(this, state, ev, mode);
 	}
-});
+	});

--- a/openwrt-packages/luci-app-nordvpn-easy/root/usr/share/rpcd/acl.d/luci-app-nordvpn-easy.json
+++ b/openwrt-packages/luci-app-nordvpn-easy/root/usr/share/rpcd/acl.d/luci-app-nordvpn-easy.json
@@ -44,6 +44,7 @@
 					"connect",
 					"disconnect",
 					"reconnect",
+					"reconcile",
 					"rotate",
 					"setup",
 					"check",

--- a/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
@@ -20,11 +20,12 @@ SERVICE_BACKEND_PAYLOAD_SIGNATURE='render-contract-v3'
 NORDVPN_EASY_RC_BUSY="${NORDVPN_EASY_RC_BUSY:-75}"
 # OpenWrt rc.common consumes the command/help metadata.
 # shellcheck disable=SC2034
-EXTRA_COMMANDS='connect disconnect reconnect setup check rotate refresh_countries refresh_countries_force server_catalog public_ip public_country operation_status vpn_status status_json diagnostics_log install_hooks remove_hooks disable_runtime render_runtime_config'
+EXTRA_COMMANDS='connect disconnect reconnect reconcile setup check rotate refresh_countries refresh_countries_force server_catalog public_ip public_country operation_status vpn_status status_json diagnostics_log install_hooks remove_hooks disable_runtime render_runtime_config'
 # shellcheck disable=SC2034
 EXTRA_HELP='  connect               Enable, run setup, then install hooks transactionally
   disconnect            Disable runtime and remove hooks
   reconnect             Run setup, then install hooks transactionally
+  reconcile             Synchronize runtime state with the saved UCI config
   setup                 Run setup immediately
   check                 Run one health check immediately
   rotate                Force server rotation immediately
@@ -539,6 +540,50 @@ reconnect() {
 	fi
 	setup || return $?
 	install_hooks
+}
+
+reconcile() {
+	local previous_failure_log_mode="${RUN_CORE_ACTION_FAILURE_LOG_MODE-}"
+	local vpn_proto vpn_disabled rc
+
+	load_service_config || return 1
+	log_service_info "reconcile requested; synchronizing runtime with saved config; $(nordvpn_easy_service_debug_summary 'cfg_')"
+
+	if [ "$cfg_enabled" -ne 1 ]; then
+		log_service_info 'reconcile: saved config is disabled; ensuring runtime is disabled'
+		disable_vpn_runtime
+		return $?
+	fi
+
+	if [ -z "$cfg_nordvpn_token" ]; then
+		log_service_error 'reconcile refused because nordvpn_token is missing'
+		return 1
+	fi
+
+	vpn_proto="$(uci -q get "network.${cfg_vpn_if}.proto" 2>/dev/null || true)"
+	vpn_disabled="$(uci -q get "network.${cfg_vpn_if}.disabled" 2>/dev/null || true)"
+	if [ "$vpn_proto" != 'wireguard' ] || [ "$vpn_disabled" = '1' ]; then
+		log_service_info "reconcile: ${cfg_vpn_if} is not active/configured (proto=${vpn_proto:-missing}, disabled=${vpn_disabled:-0}); running connect"
+		connect
+		return $?
+	fi
+
+	RUN_CORE_ACTION_FAILURE_LOG_MODE='info'
+	if run_core_action check; then
+		RUN_CORE_ACTION_FAILURE_LOG_MODE="$previous_failure_log_mode"
+		install_hooks
+		return $?
+	fi
+	rc=$?
+	RUN_CORE_ACTION_FAILURE_LOG_MODE="$previous_failure_log_mode"
+
+	if [ "$rc" -eq "${NORDVPN_EASY_RC_BUSY:-75}" ]; then
+		log_service_info 'reconcile skipped because another operation is running'
+		return "$rc"
+	fi
+
+	log_service_info 'reconcile: health check did not validate the runtime; running reconnect'
+	reconnect
 }
 
 setup() {

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/migrate-config.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/migrate-config.sh
@@ -75,52 +75,28 @@ read_legacy_option() {
 	read_uci_file_option "$LEGACY_CONFIG_FILE" "$1"
 }
 
-source_has_custom_values() {
-	local source="$1"
-	local option value normalized_value default_value
-
-	for option in $(nordvpn_easy_uci_options); do
-		[ "$option" = 'config_schema_version' ] && continue
-
-		case "$source" in
-			active)
-				active_option_exists "$option" || continue
-				value="$(read_active_option "$option")"
-				;;
-			legacy)
-				value="$(read_legacy_option "$option")" || continue
-				;;
-			*)
-				return 1
-				;;
-		esac
-
-		normalized_value="$(nordvpn_easy_normalize_value "$option" "$value")"
-		default_value="$(nordvpn_easy_default "$option" 2>/dev/null || printf '%s' '')"
-		[ "$normalized_value" != "$default_value" ] && return 0
-	done
-
-	return 1
-}
-
 read_snapshot_option() {
 	local option="$1"
-	local active_has_custom="$2"
-	local legacy_has_custom="$3"
-	local value
+	local active_value legacy_value normalized_value default_value
 
-	if [ "$legacy_has_custom" -eq 1 ] && [ "$active_has_custom" -eq 0 ] && value="$(read_legacy_option "$option")"; then
-		printf '%s' "$value"
+	default_value="$(nordvpn_easy_default "$option" 2>/dev/null || printf '%s' '')"
+
+	if active_option_exists "$option"; then
+		active_value="$(read_active_option "$option")"
+		normalized_value="$(nordvpn_easy_normalize_value "$option" "$active_value")"
+		if [ "$option" = 'config_schema_version' ] || [ "$normalized_value" != "$default_value" ]; then
+			printf '%s' "$active_value"
+			return 0
+		fi
+	fi
+
+	if legacy_value="$(read_legacy_option "$option")"; then
+		printf '%s' "$legacy_value"
 		return 0
 	fi
 
 	if active_option_exists "$option"; then
-		read_active_option "$option"
-		return 0
-	fi
-
-	if value="$(read_legacy_option "$option")"; then
-		printf '%s' "$value"
+		printf '%s' "$active_value"
 		return 0
 	fi
 
@@ -129,14 +105,9 @@ read_snapshot_option() {
 
 snapshot_existing_config() {
 	local option old_value normalized_value
-	local active_has_custom=0
-	local legacy_has_custom=0
-
-	source_has_custom_values active && active_has_custom=1
-	source_has_custom_values legacy && legacy_has_custom=1
 
 	for option in $(nordvpn_easy_uci_options); do
-		old_value="$(read_snapshot_option "$option" "$active_has_custom" "$legacy_has_custom")"
+		old_value="$(read_snapshot_option "$option")"
 		normalized_value="$(nordvpn_easy_normalize_value "$option" "$old_value")"
 		eval "snapshot_${option}='$(nordvpn_easy_shell_quote "$normalized_value")'"
 	done

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/migrate-config.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/migrate-config.sh
@@ -21,15 +21,125 @@ trap cleanup EXIT HUP INT TERM
 # shellcheck disable=SC1090
 . "$SCHEMA_LIB" || exit 1
 
-read_existing_option() {
+read_active_option() {
 	uci -q get "${UCI_CONFIG}.${UCI_SECTION}.${1}" || printf '%s' ''
+}
+
+active_option_exists() {
+	uci -q get "${UCI_CONFIG}.${UCI_SECTION}.${1}" >/dev/null 2>&1
+}
+
+read_uci_file_option() {
+	local file_path="$1"
+	local option="$2"
+
+	[ -r "$file_path" ] || return 1
+
+	awk -v wanted="$option" '
+		function trim(value) {
+			sub(/^[[:space:]]+/, "", value)
+			sub(/[[:space:]]+$/, "", value)
+			return value
+		}
+
+		function unquote(value, quote) {
+			value = trim(value)
+			quote = substr(value, 1, 1)
+			if ((quote == "\047" || quote == "\"") && substr(value, length(value), 1) == quote)
+				value = substr(value, 2, length(value) - 2)
+			return value
+		}
+
+		$1 == "config" {
+			section_type = unquote($2)
+			section_name = unquote($3)
+			in_main = (section_type == "nordvpn_easy" && section_name == "main")
+		}
+
+		in_main && $1 == "option" && $2 == wanted {
+			value = $0
+			sub(/^[[:space:]]*option[[:space:]]+[^[:space:]]+[[:space:]]+/, "", value)
+			print unquote(value)
+			found = 1
+			exit
+		}
+
+		END {
+			exit(found ? 0 : 1)
+		}
+	' "$file_path"
+}
+
+read_opkg_option() {
+	read_uci_file_option "$OPKG_CONFIG_FILE" "$1"
+}
+
+opkg_option_exists() {
+	read_opkg_option "$1" >/dev/null 2>&1
+}
+
+source_has_custom_values() {
+	local source="$1"
+	local option value normalized_value default_value
+
+	for option in $(nordvpn_easy_uci_options); do
+		[ "$option" = 'config_schema_version' ] && continue
+
+		case "$source" in
+			active)
+				active_option_exists "$option" || continue
+				value="$(read_active_option "$option")"
+				;;
+			opkg)
+				value="$(read_opkg_option "$option")" || continue
+				;;
+			*)
+				return 1
+				;;
+		esac
+
+		normalized_value="$(nordvpn_easy_normalize_value "$option" "$value")"
+		default_value="$(nordvpn_easy_default "$option" 2>/dev/null || printf '%s' '')"
+		[ "$normalized_value" != "$default_value" ] && return 0
+	done
+
+	return 1
+}
+
+read_snapshot_option() {
+	local option="$1"
+	local active_has_custom="$2"
+	local opkg_has_custom="$3"
+	local value
+
+	if [ "$opkg_has_custom" -eq 1 ] && [ "$active_has_custom" -eq 0 ] && value="$(read_opkg_option "$option")"; then
+		printf '%s' "$value"
+		return 0
+	fi
+
+	if active_option_exists "$option"; then
+		read_active_option "$option"
+		return 0
+	fi
+
+	if value="$(read_opkg_option "$option")"; then
+		printf '%s' "$value"
+		return 0
+	fi
+
+	printf '%s' ''
 }
 
 snapshot_existing_config() {
 	local option old_value normalized_value
+	local active_has_custom=0
+	local opkg_has_custom=0
+
+	source_has_custom_values active && active_has_custom=1
+	source_has_custom_values opkg && opkg_has_custom=1
 
 	for option in $(nordvpn_easy_uci_options); do
-		old_value="$(read_existing_option "$option")"
+		old_value="$(read_snapshot_option "$option" "$active_has_custom" "$opkg_has_custom")"
 		normalized_value="$(nordvpn_easy_normalize_value "$option" "$old_value")"
 		eval "snapshot_${option}='$(nordvpn_easy_shell_quote "$normalized_value")'"
 	done

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/migrate-config.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/migrate-config.sh
@@ -5,7 +5,8 @@ set -eu
 UCI_CONFIG="${NORDVPN_EASY_UCI_CONFIG:-nordvpn_easy}"
 UCI_SECTION="${NORDVPN_EASY_UCI_SECTION:-main}"
 CONFIG_FILE="${NORDVPN_EASY_CONFIG_FILE:-/etc/config/nordvpn_easy}"
-OPKG_CONFIG_FILE="${NORDVPN_EASY_OPKG_CONFIG_FILE:-/etc/config/nordvpn_easy-opkg}"
+# Keep the old OPKG variable as a compatibility alias for existing test harnesses or local scripts.
+LEGACY_CONFIG_FILE="${NORDVPN_EASY_LEGACY_CONFIG_FILE:-${NORDVPN_EASY_OPKG_CONFIG_FILE:-/etc/config/nordvpn_easy-opkg}}"
 TEMPLATE_FILE="${NORDVPN_EASY_TEMPLATE_FILE:-/usr/share/nordvpn-easy/defaults/nordvpn_easy}"
 LIB_DIR="${NORDVPN_EASY_LIB_DIR:-/usr/libexec/nordvpn-easy/lib}"
 SCHEMA_LIB="${LIB_DIR}/schema.sh"
@@ -70,12 +71,8 @@ read_uci_file_option() {
 	' "$file_path"
 }
 
-read_opkg_option() {
-	read_uci_file_option "$OPKG_CONFIG_FILE" "$1"
-}
-
-opkg_option_exists() {
-	read_opkg_option "$1" >/dev/null 2>&1
+read_legacy_option() {
+	read_uci_file_option "$LEGACY_CONFIG_FILE" "$1"
 }
 
 source_has_custom_values() {
@@ -90,8 +87,8 @@ source_has_custom_values() {
 				active_option_exists "$option" || continue
 				value="$(read_active_option "$option")"
 				;;
-			opkg)
-				value="$(read_opkg_option "$option")" || continue
+			legacy)
+				value="$(read_legacy_option "$option")" || continue
 				;;
 			*)
 				return 1
@@ -109,10 +106,10 @@ source_has_custom_values() {
 read_snapshot_option() {
 	local option="$1"
 	local active_has_custom="$2"
-	local opkg_has_custom="$3"
+	local legacy_has_custom="$3"
 	local value
 
-	if [ "$opkg_has_custom" -eq 1 ] && [ "$active_has_custom" -eq 0 ] && value="$(read_opkg_option "$option")"; then
+	if [ "$legacy_has_custom" -eq 1 ] && [ "$active_has_custom" -eq 0 ] && value="$(read_legacy_option "$option")"; then
 		printf '%s' "$value"
 		return 0
 	fi
@@ -122,7 +119,7 @@ read_snapshot_option() {
 		return 0
 	fi
 
-	if value="$(read_opkg_option "$option")"; then
+	if value="$(read_legacy_option "$option")"; then
 		printf '%s' "$value"
 		return 0
 	fi
@@ -133,13 +130,13 @@ read_snapshot_option() {
 snapshot_existing_config() {
 	local option old_value normalized_value
 	local active_has_custom=0
-	local opkg_has_custom=0
+	local legacy_has_custom=0
 
 	source_has_custom_values active && active_has_custom=1
-	source_has_custom_values opkg && opkg_has_custom=1
+	source_has_custom_values legacy && legacy_has_custom=1
 
 	for option in $(nordvpn_easy_uci_options); do
-		old_value="$(read_snapshot_option "$option" "$active_has_custom" "$opkg_has_custom")"
+		old_value="$(read_snapshot_option "$option" "$active_has_custom" "$legacy_has_custom")"
 		normalized_value="$(nordvpn_easy_normalize_value "$option" "$old_value")"
 		eval "snapshot_${option}='$(nordvpn_easy_shell_quote "$normalized_value")'"
 	done
@@ -182,4 +179,4 @@ apply_snapshot_to_uci() {
 snapshot_existing_config
 install_template_config
 apply_snapshot_to_uci
-rm -f -- "$OPKG_CONFIG_FILE"
+rm -f -- "$LEGACY_CONFIG_FILE"

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy
@@ -202,11 +202,14 @@ rpc_call() {
 		disconnect)
 			rpc_disconnect
 			;;
-		reconnect)
-			rpc_reconnect
-			;;
-		rotate)
-			rpc_command_result 'rotate' "$INIT_SCRIPT" rotate
+			reconnect)
+				rpc_reconnect
+				;;
+			reconcile)
+				rpc_command_result 'reconcile' "$INIT_SCRIPT" reconcile
+				;;
+			rotate)
+				rpc_command_result 'rotate' "$INIT_SCRIPT" rotate
 			;;
 		setup)
 			rpc_command_result 'setup' "$INIT_SCRIPT" setup
@@ -249,10 +252,11 @@ case "$1" in
 		cat <<'EOF'
 {
   "status": {},
-  "connect": {},
-  "disconnect": {},
-  "reconnect": {},
-  "rotate": {},
+	  "connect": {},
+	  "disconnect": {},
+	  "reconnect": {},
+	  "reconcile": {},
+	  "rotate": {},
   "setup": {},
   "check": {},
   "install_hooks": {},

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy
@@ -202,14 +202,14 @@ rpc_call() {
 		disconnect)
 			rpc_disconnect
 			;;
-			reconnect)
-				rpc_reconnect
-				;;
-			reconcile)
-				rpc_command_result 'reconcile' "$INIT_SCRIPT" reconcile
-				;;
-			rotate)
-				rpc_command_result 'rotate' "$INIT_SCRIPT" rotate
+		reconnect)
+			rpc_reconnect
+			;;
+		reconcile)
+			rpc_command_result 'reconcile' "$INIT_SCRIPT" reconcile
+			;;
+		rotate)
+			rpc_command_result 'rotate' "$INIT_SCRIPT" rotate
 			;;
 		setup)
 			rpc_command_result 'setup' "$INIT_SCRIPT" setup
@@ -252,11 +252,11 @@ case "$1" in
 		cat <<'EOF'
 {
   "status": {},
-	  "connect": {},
-	  "disconnect": {},
-	  "reconnect": {},
-	  "reconcile": {},
-	  "rotate": {},
+  "connect": {},
+  "disconnect": {},
+  "reconnect": {},
+  "reconcile": {},
+  "rotate": {},
   "setup": {},
   "check": {},
   "install_hooks": {},

--- a/tests/nordvpn-easy/test-config.js
+++ b/tests/nordvpn-easy/test-config.js
@@ -522,13 +522,13 @@ async function testLoadUsesCachedCountriesWithoutBlockingOnManualCatalog() {
 		normalizeValue(harness.calls.service.map(function(call) {
 			return [ call.action, call.args ];
 		})),
-			[
-				[ 'status_json', [] ]
-			],
-			'idle manual configuration loads status without blocking on server catalog refresh'
-		);
-		assert.equal(data[2], null, 'manual server catalog is loaded after render');
-}
+		[
+			[ 'status_json', [] ]
+		],
+		'idle manual configuration loads status without blocking initial render on server catalog data'
+	);
+	assert.equal(data[2], null, 'manual server catalog is loaded after render');
+	}
 
 async function testLoadSkipsRefreshesWhenRuntimeBusy() {
 	const harness = loadConfigView({

--- a/tests/nordvpn-easy/test-config.js
+++ b/tests/nordvpn-easy/test-config.js
@@ -261,9 +261,9 @@ function loadConfigView(options) {
 		renderCountryChoices: [],
 		renderLocalStatusSnapshot: [],
 		updateLocalStatus: [],
-			updatePublicIp: [],
-			loadServerCatalog: [],
-			updateServerSelectionState: [],
+		updatePublicIp: [],
+		loadServerCatalog: [],
+		updateServerSelectionState: [],
 		onCountryChanged: 0,
 		onModeChanged: 0,
 		pollingStart: []

--- a/tests/nordvpn-easy/test-config.js
+++ b/tests/nordvpn-easy/test-config.js
@@ -261,8 +261,9 @@ function loadConfigView(options) {
 		renderCountryChoices: [],
 		renderLocalStatusSnapshot: [],
 		updateLocalStatus: [],
-		updatePublicIp: [],
-		updateServerSelectionState: [],
+			updatePublicIp: [],
+			loadServerCatalog: [],
+			updateServerSelectionState: [],
 		onCountryChanged: 0,
 		onModeChanged: 0,
 		pollingStart: []
@@ -330,14 +331,22 @@ function loadConfigView(options) {
 				});
 				return Promise.resolve();
 			},
-			updatePublicIp(renderState, updateOptions) {
-				calls.updatePublicIp.push({
-					state: renderState,
-					options: normalizeValue(updateOptions)
-				});
-				return Promise.resolve();
-			},
-			onCountryChanged() {
+				updatePublicIp(renderState, updateOptions) {
+					calls.updatePublicIp.push({
+						state: renderState,
+						options: normalizeValue(updateOptions)
+					});
+					return Promise.resolve();
+				},
+				loadServerCatalog(renderState, country, forceRefresh) {
+					calls.loadServerCatalog.push({
+						state: renderState,
+						country: country,
+						forceRefresh: forceRefresh
+					});
+					return Promise.resolve();
+				},
+				onCountryChanged() {
 				calls.onCountryChanged++;
 			},
 			onModeChanged() {
@@ -491,7 +500,7 @@ function loadConfigView(options) {
 	};
 }
 
-async function testLoadUsesCachedCountriesAndLoadsManualCatalogWhenIdle() {
+async function testLoadUsesCachedCountriesWithoutBlockingOnManualCatalog() {
 	const harness = loadConfigView({
 		fsReadResponses: [
 			'[]'
@@ -513,13 +522,12 @@ async function testLoadUsesCachedCountriesAndLoadsManualCatalogWhenIdle() {
 		normalizeValue(harness.calls.service.map(function(call) {
 			return [ call.action, call.args ];
 		})),
-		[
-			[ 'status_json', [] ],
-			[ 'server_catalog', [ 'UY' ] ]
-		],
-		'idle manual configuration loads status and selected-country server catalog without blocking on country refresh'
-	);
-	assert.equal(data[2].code, 0, 'manual server catalog response is returned to render');
+			[
+				[ 'status_json', [] ]
+			],
+			'idle manual configuration loads status without blocking on server catalog refresh'
+		);
+		assert.equal(data[2], null, 'manual server catalog is loaded after render');
 }
 
 async function testLoadSkipsRefreshesWhenRuntimeBusy() {
@@ -621,6 +629,7 @@ async function testRenderWiresInitialStateAndLiveHandlers() {
 		return call.options;
 	}), [ { force: true } ], 'enabled configuration starts a forced public-IP refresh');
 	assert.equal(harness.calls.renderServerChoices.length, 1, 'render refreshes server choices after the map node exists');
+	assert.equal(harness.calls.loadServerCatalog.length, 0, 'render does not refresh server catalog when initial catalog is already present');
 	assert.equal(harness.calls.updateServerSelectionState.length, 1, 'render updates server-selection state after wiring controls');
 	assert.deepEqual(harness.calls.pollingStart, [ harness.state ], 'render starts manager polling with the shared state');
 
@@ -628,6 +637,45 @@ async function testRenderWiresInitialStateAndLiveHandlers() {
 	harness.selectElements['cbid.nordvpn_easy.main.server_selection_mode'].handlers[0].handler();
 	assert.equal(harness.calls.onCountryChanged, 1, 'country select change delegates to manager-actions');
 	assert.equal(harness.calls.onModeChanged, 1, 'mode select change delegates to manager-actions');
+}
+
+async function testRenderLoadsManualCatalogInBackgroundAfterInitialPaint() {
+	const statusResult = {
+		code: 0,
+		stdout: JSON.stringify({
+			desired_enabled: true,
+			runtime_disabled: false,
+			interface_disabled: false,
+			runtime_configured: true,
+			selected_country: 'UY',
+			server_selection_mode: 'manual',
+			operation_status: 'idle'
+		}),
+		stderr: ''
+	};
+	const harness = loadConfigView({
+		uciValues: {
+			enabled: '1',
+			vpn_country: 'UY',
+			server_selection_mode: 'manual',
+			preferred_server_station: ''
+		}
+	});
+
+	await harness.view.render([ JSON.stringify([ { name: 'Uruguay', code: 'UY' } ]), statusResult, null ]);
+	await Promise.resolve();
+
+	assert.equal(harness.state.currentServerCatalog.servers.length, 0, 'initial render is not blocked by server catalog data');
+	assert.deepEqual(
+		harness.calls.loadServerCatalog.map(function(call) {
+			return {
+				country: call.country,
+				forceRefresh: call.forceRefresh
+			};
+		}),
+		[ { country: 'UY', forceRefresh: false } ],
+		'manual server catalog refresh starts in the background after render'
+	);
 }
 
 async function testRenderRefreshesEmptyCountryCacheInBackground() {
@@ -682,9 +730,10 @@ async function testRenderRefreshesEmptyCountryCacheInBackground() {
 }
 
 Promise.resolve().then(async function() {
-	await testLoadUsesCachedCountriesAndLoadsManualCatalogWhenIdle();
+	await testLoadUsesCachedCountriesWithoutBlockingOnManualCatalog();
 	await testLoadSkipsRefreshesWhenRuntimeBusy();
 	await testRenderWiresInitialStateAndLiveHandlers();
+	await testRenderLoadsManualCatalogInBackgroundAfterInitialPaint();
 	await testRenderRefreshesEmptyCountryCacheInBackground();
 	console.log('test-config.js: ok');
 }).catch(function(err) {

--- a/tests/nordvpn-easy/test-config.js
+++ b/tests/nordvpn-easy/test-config.js
@@ -552,7 +552,7 @@ async function testLoadSkipsRefreshesWhenRuntimeBusy() {
 		[ [ 'status_json', [] ] ],
 		'busy runtime skips country refresh and server catalog loading'
 	);
-	assert.equal(data[2], null, 'busy runtime returns no server catalog response');
+	assert.equal(data[2], null, 'load never returns a synchronous server catalog response');
 }
 
 async function testRenderWiresInitialStateAndLiveHandlers() {

--- a/tests/nordvpn-easy/test-config.js
+++ b/tests/nordvpn-easy/test-config.js
@@ -331,22 +331,22 @@ function loadConfigView(options) {
 				});
 				return Promise.resolve();
 			},
-				updatePublicIp(renderState, updateOptions) {
-					calls.updatePublicIp.push({
-						state: renderState,
-						options: normalizeValue(updateOptions)
-					});
-					return Promise.resolve();
-				},
-				loadServerCatalog(renderState, country, forceRefresh) {
-					calls.loadServerCatalog.push({
-						state: renderState,
-						country: country,
-						forceRefresh: forceRefresh
-					});
-					return Promise.resolve();
-				},
-				onCountryChanged() {
+			updatePublicIp(renderState, updateOptions) {
+				calls.updatePublicIp.push({
+					state: renderState,
+					options: normalizeValue(updateOptions)
+				});
+				return Promise.resolve();
+			},
+			loadServerCatalog(renderState, country, forceRefresh) {
+				calls.loadServerCatalog.push({
+					state: renderState,
+					country: country,
+					forceRefresh: forceRefresh
+				});
+				return Promise.resolve();
+			},
+			onCountryChanged() {
 				calls.onCountryChanged++;
 			},
 			onModeChanged() {

--- a/tests/nordvpn-easy/test-init-run-core.sh
+++ b/tests/nordvpn-easy/test-init-run-core.sh
@@ -43,6 +43,7 @@ eval "$(extract_function run_core_action)"
 eval "$(extract_function connect)"
 eval "$(extract_function disconnect)"
 eval "$(extract_function reconnect)"
+eval "$(extract_function reconcile)"
 
 load_service_config() { :; }
 log_service_info() { printf '%s\n' "$1" >> "$INFO_CAPTURE"; }
@@ -79,6 +80,8 @@ nordvpn_easy_validate_runtime_config() {
 
 UCI_SET_VALUES=''
 UCI_COMMIT_COUNT=0
+NETWORK_PROTO=''
+NETWORK_DISABLED=''
 SETUP_COUNT=0
 SETUP_RC=0
 INSTALL_HOOKS_COUNT=0
@@ -86,7 +89,26 @@ DISABLE_RUNTIME_COUNT=0
 UCI_CONFIG='nordvpn_easy'
 UCI_SECTION='main'
 uci() {
+	if [ "${1:-}" = '-q' ]; then
+		shift
+	fi
+
 	case "$1" in
+		get)
+			case "$2" in
+				network.wg0.proto)
+					[ -n "$NETWORK_PROTO" ] || return 1
+					printf '%s\n' "$NETWORK_PROTO"
+					return 0
+					;;
+				network.wg0.disabled)
+					[ -n "$NETWORK_DISABLED" ] || return 1
+					printf '%s\n' "$NETWORK_DISABLED"
+					return 0
+					;;
+			esac
+			return 1
+			;;
 		set)
 			UCI_SET_VALUES="${UCI_SET_VALUES}${2};"
 			return 0
@@ -112,6 +134,8 @@ disable_vpn_runtime() {
 }
 
 cfg_enabled=0
+cfg_nordvpn_token=''
+cfg_vpn_if='wg0'
 SETUP_RC=1
 RC=0
 connect || RC=$?
@@ -157,6 +181,47 @@ case "$UCI_SET_VALUES" in
 		;;
 	*)
 		printf '%s\n' 'FAIL: disconnect should set enabled=0 before disabling runtime' >&2
+		exit 1
+		;;
+esac
+
+cfg_enabled=0
+cfg_nordvpn_token='token-secret'
+cfg_vpn_if='wg0'
+DISABLE_RUNTIME_COUNT=0
+RC=0
+reconcile || RC=$?
+assert_eq '0' "$RC" 'reconcile succeeds while ensuring disabled runtime'
+assert_eq '1' "$DISABLE_RUNTIME_COUNT" 'reconcile disables runtime when saved config is disabled'
+
+cfg_enabled=1
+cfg_nordvpn_token=''
+DISABLE_RUNTIME_COUNT=0
+SETUP_COUNT=0
+RC=0
+reconcile || RC=$?
+assert_eq '1' "$RC" 'reconcile rejects enabled config without token'
+assert_eq '0' "$SETUP_COUNT" 'reconcile does not start setup when token is missing'
+
+cfg_enabled=1
+cfg_nordvpn_token='token-secret'
+cfg_vpn_if='wg0'
+NETWORK_PROTO=''
+NETWORK_DISABLED=''
+SETUP_RC=0
+SETUP_COUNT=0
+INSTALL_HOOKS_COUNT=0
+UCI_SET_VALUES=''
+RC=0
+reconcile || RC=$?
+assert_eq '0' "$RC" 'reconcile connects when WireGuard interface is missing'
+assert_eq '1' "$SETUP_COUNT" 'reconcile runs setup through connect when runtime is missing'
+assert_eq '1' "$INSTALL_HOOKS_COUNT" 'reconcile installs hooks after reconnecting missing runtime'
+case "$UCI_SET_VALUES" in
+	*nordvpn_easy.main.enabled=1\;*)
+		;;
+	*)
+		printf '%s\n' 'FAIL: reconcile connect path should keep enabled=1' >&2
 		exit 1
 		;;
 esac

--- a/tests/nordvpn-easy/test-manager-actions.js
+++ b/tests/nordvpn-easy/test-manager-actions.js
@@ -286,7 +286,7 @@ assert.deepEqual(
 assert.deepEqual(
 	normalizeValue(managerActions.deriveRuntimeActionPlan(true, true, 'UY', 'UY', 'auto', 'auto', '', '', disabledRuntime)),
 	{
-		actions: [ 'reconnect' ],
+		actions: [ 'reconcile' ],
 		successMessage: 'NordVPN Easy runtime synchronized with the saved configuration.',
 		serverSelectionChanged: false
 	},
@@ -296,7 +296,7 @@ assert.deepEqual(
 assert.deepEqual(
 	normalizeValue(managerActions.deriveRuntimeActionPlan(true, true, 'UY', 'UY', 'auto', 'auto', '', '', missingRuntime)),
 	{
-		actions: [ 'reconnect' ],
+		actions: [ 'reconcile' ],
 		successMessage: 'NordVPN Easy runtime synchronized with the saved configuration.',
 		serverSelectionChanged: false
 	},
@@ -306,7 +306,7 @@ assert.deepEqual(
 assert.deepEqual(
 	normalizeValue(managerActions.deriveRuntimeActionPlan(true, true, 'UY', 'UY', 'auto', 'auto', '', '', unknownRuntime)),
 	{
-		actions: [ 'reconnect' ],
+		actions: [ 'reconcile' ],
 		successMessage: 'NordVPN Easy runtime synchronized with the saved configuration.',
 		serverSelectionChanged: false
 	},
@@ -316,7 +316,7 @@ assert.deepEqual(
 assert.deepEqual(
 	normalizeValue(managerActions.deriveRuntimeActionPlan(true, true, 'UY', 'UY', 'auto', 'auto', '', '', null)),
 	{
-		actions: [ 'reconnect' ],
+		actions: [ 'reconcile' ],
 		successMessage: 'NordVPN Easy runtime synchronized with the saved configuration.',
 		serverSelectionChanged: false
 	},
@@ -1237,6 +1237,36 @@ async function testHandleSaveApplyAutoModeClearsManualSelectionAndReconnects() {
 	assert.ok(harness.serviceCalls.indexOf('status_json') !== -1, 'save/apply refreshes local status during the flow');
 }
 
+async function testHandleSaveApplyReconcilesDisabledRuntimeAfterSave() {
+	const harness = buildHandleSaveApplyHarness({
+		previousEnabled: true,
+		previousCountry: 'UY',
+		currentEnabled: true,
+		currentMode: 'auto',
+		currentCountry: 'UY',
+		savedEnabled: '1',
+		savedCountry: 'UY',
+		statusPayload: {
+			desired_enabled: true,
+			runtime_disabled: true,
+			interface_disabled: true,
+			runtime_configured: true,
+			operation_status: 'idle',
+			selected_country: 'UY',
+			server_selection_mode: 'auto',
+			preferred_server_station: ''
+		}
+	});
+
+	await harness.actions.handleSaveApply(harness.viewState, harness.state, {}, '1');
+	await Promise.resolve();
+	await Promise.resolve();
+
+	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'reconcile' ] ], 'unchanged enabled config reconciles a disabled runtime after Save & Apply');
+	assert.equal(harness.state.pendingOperationLabel, '', 'reconcile completion clears pending operation label');
+	assert.ok(harness.serviceCalls.indexOf('status_json') !== -1, 'reconcile flow refreshes status before choosing runtime action');
+}
+
 Promise.resolve().then(async function() {
 	await testUpdateLocalStatusMarksSnapshotsStaleOnFailedResponse();
 	await testUpdateLocalStatusMarksSnapshotsStaleOnRejectedExec();
@@ -1250,6 +1280,7 @@ Promise.resolve().then(async function() {
 	await testHandleSaveApplyContinuesWhenUciAppliedEventIsMissing();
 	await testHandleSaveApplyClearsBusyStateWhenPostApplySyncFails();
 	await testHandleSaveApplyAutoModeClearsManualSelectionAndReconnects();
+	await testHandleSaveApplyReconcilesDisabledRuntimeAfterSave();
 	console.log('test-manager-actions.js: ok');
 }).catch(function(err) {
 	console.error(err);

--- a/tests/nordvpn-easy/test-migrate-config.sh
+++ b/tests/nordvpn-easy/test-migrate-config.sh
@@ -245,6 +245,27 @@ assert_file_has_line "	option wireguard_mtu '1412'" "$FAKE_UCI_CONFIG_FILE" 'leg
 reset_fake_uci
 set_store_value '__section__' 'nordvpn_easy'
 set_store_value 'enabled' '1'
+set_store_value 'vpn_country' ''
+cat > "$FAKE_LEGACY_CONFIG_FILE" <<'EOF'
+config nordvpn_easy 'main'
+	option vpn_country 'BM'
+	option nordvpn_token 'mixed-source-token'
+EOF
+
+run_migrator
+
+assert_file_has_line "	option enabled '1'" "$FAKE_UCI_CONFIG_FILE" 'mixed source preserves active enabled flag'
+assert_file_has_line "	option vpn_country 'BM'" "$FAKE_UCI_CONFIG_FILE" 'mixed source recovers legacy country when active country is default'
+assert_file_has_line "	option nordvpn_token 'mixed-source-token'" "$FAKE_UCI_CONFIG_FILE" 'mixed source recovers legacy token when active token is missing'
+
+[ ! -e "$FAKE_LEGACY_CONFIG_FILE" ] || {
+	printf '%s\n' 'FAIL: migrator did not remove mixed-source legacy config file' >&2
+	exit 1
+}
+
+reset_fake_uci
+set_store_value '__section__' 'nordvpn_easy'
+set_store_value 'enabled' '1'
 set_store_value 'nordvpn_token' 'active-secret-token'
 set_store_value 'vpn_country' 'CH'
 cat > "$FAKE_LEGACY_CONFIG_FILE" <<'EOF'

--- a/tests/nordvpn-easy/test-migrate-config.sh
+++ b/tests/nordvpn-easy/test-migrate-config.sh
@@ -213,4 +213,55 @@ assert_file_missing_line "	option nordvpn_basic_token 'legacy-token'" "$FAKE_UCI
 	exit 1
 }
 
+reset_fake_uci
+cat > "$FAKE_OPKG_CONFIG_FILE" <<'EOF'
+config nordvpn_easy 'main'
+	option enabled 'yes'
+	option nordvpn_token 'opkg-secret-token'
+	option vpn_country 'BM'
+	option server_selection_mode 'manual'
+	option preferred_server_hostname "bm1.nordvpn.com"
+	option preferred_server_station 'bm1'
+	option check_cron_schedule '*/5 * * * *'
+	option wireguard_mtu '1412'
+EOF
+
+run_migrator
+
+assert_file_has_line "	option enabled '1'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery normalizes enabled flag'
+assert_file_has_line "	option nordvpn_token 'opkg-secret-token'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves NordVPN token'
+assert_file_has_line "	option vpn_country 'BM'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves selected country'
+assert_file_has_line "	option server_selection_mode 'manual'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves manual mode'
+assert_file_has_line "	option preferred_server_hostname 'bm1.nordvpn.com'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery parses double-quoted hostname'
+assert_file_has_line "	option preferred_server_station 'bm1'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves manual station'
+assert_file_has_line "	option check_cron_schedule '*/5 * * * *'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves cron schedule'
+assert_file_has_line "	option wireguard_mtu '1412'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves WireGuard MTU'
+
+[ ! -e "$FAKE_OPKG_CONFIG_FILE" ] || {
+	printf '%s\n' 'FAIL: migrator did not remove recovered nordvpn_easy-opkg file' >&2
+	exit 1
+}
+
+reset_fake_uci
+set_store_value '__section__' 'nordvpn_easy'
+set_store_value 'enabled' '1'
+set_store_value 'nordvpn_token' 'active-secret-token'
+set_store_value 'vpn_country' 'CH'
+cat > "$FAKE_OPKG_CONFIG_FILE" <<'EOF'
+config nordvpn_easy 'main'
+	option enabled 'yes'
+	option nordvpn_token 'stale-opkg-token'
+	option vpn_country 'AT'
+EOF
+
+run_migrator
+
+assert_file_has_line "	option nordvpn_token 'active-secret-token'" "$FAKE_UCI_CONFIG_FILE" 'active config wins over stale opkg token'
+assert_file_has_line "	option vpn_country 'CH'" "$FAKE_UCI_CONFIG_FILE" 'active config wins over stale opkg country'
+
+[ ! -e "$FAKE_OPKG_CONFIG_FILE" ] || {
+	printf '%s\n' 'FAIL: migrator did not remove stale nordvpn_easy-opkg after active config won' >&2
+	exit 1
+}
+
 printf '%s\n' 'test-migrate-config.sh: ok'

--- a/tests/nordvpn-easy/test-migrate-config.sh
+++ b/tests/nordvpn-easy/test-migrate-config.sh
@@ -12,7 +12,7 @@ FAKE_BIN="$TMP_DIR/bin"
 FAKE_UCI_STORE_DIR="$TMP_DIR/uci-store"
 FAKE_UCI_CONFIG_FILE="$TMP_DIR/etc/config/nordvpn_easy"
 FAKE_UCI_OPTIONS_FILE="$TMP_DIR/options"
-FAKE_OPKG_CONFIG_FILE="$TMP_DIR/etc/config/nordvpn_easy-opkg"
+FAKE_LEGACY_CONFIG_FILE="$TMP_DIR/etc/config/nordvpn_easy-opkg"
 
 cleanup() {
 	rm -rf "$TMP_DIR"
@@ -137,21 +137,21 @@ set_store_value() {
 
 run_migrator() {
 	config_file="$FAKE_UCI_CONFIG_FILE"
-	opkg_config_file="$FAKE_OPKG_CONFIG_FILE"
+	legacy_config_file="$FAKE_LEGACY_CONFIG_FILE"
 
 	PATH="$FAKE_BIN:$PATH" \
 	FAKE_UCI_STORE_DIR="$FAKE_UCI_STORE_DIR" \
 	FAKE_UCI_CONFIG_FILE="$config_file" \
 	FAKE_UCI_OPTIONS_FILE="$FAKE_UCI_OPTIONS_FILE" \
 	NORDVPN_EASY_CONFIG_FILE="$config_file" \
-	NORDVPN_EASY_OPKG_CONFIG_FILE="$opkg_config_file" \
+	NORDVPN_EASY_LEGACY_CONFIG_FILE="$legacy_config_file" \
 	NORDVPN_EASY_TEMPLATE_FILE="$TEMPLATE_FILE" \
 	NORDVPN_EASY_LIB_DIR="$LIB_DIR" \
 	"$MIGRATOR"
 }
 
 reset_fake_uci
-rm -f "$FAKE_UCI_CONFIG_FILE" "$FAKE_OPKG_CONFIG_FILE"
+rm -f "$FAKE_UCI_CONFIG_FILE" "$FAKE_LEGACY_CONFIG_FILE"
 run_migrator
 
 [ -f "$FAKE_UCI_CONFIG_FILE" ] || {
@@ -190,7 +190,7 @@ set_store_value 'wan_if' 'wan6'
 set_store_value 'server_cache_ttl' 'not-a-number'
 set_store_value 'wireguard_mtu' '1420'
 set_store_value 'kill_switch_enabled' 'on'
-printf '%s\n' 'stale opkg conffile' > "$FAKE_OPKG_CONFIG_FILE"
+printf '%s\n' 'stale legacy conffile' > "$FAKE_LEGACY_CONFIG_FILE"
 
 run_migrator
 
@@ -208,16 +208,16 @@ assert_file_has_line "	option fallback_server_station ''" "$FAKE_UCI_CONFIG_FILE
 assert_file_has_line "	option config_schema_version '$NORDVPN_EASY_SCHEMA_VERSION'" "$FAKE_UCI_CONFIG_FILE" 'upgrade writes current schema version'
 assert_file_missing_line "	option nordvpn_basic_token 'legacy-token'" "$FAKE_UCI_CONFIG_FILE" 'upgrade removes legacy basic token option'
 
-[ ! -e "$FAKE_OPKG_CONFIG_FILE" ] || {
+[ ! -e "$FAKE_LEGACY_CONFIG_FILE" ] || {
 	printf '%s\n' 'FAIL: migrator did not remove stale nordvpn_easy-opkg file' >&2
 	exit 1
 }
 
 reset_fake_uci
-cat > "$FAKE_OPKG_CONFIG_FILE" <<'EOF'
+cat > "$FAKE_LEGACY_CONFIG_FILE" <<'EOF'
 config nordvpn_easy 'main'
 	option enabled 'yes'
-	option nordvpn_token 'opkg-secret-token'
+	option nordvpn_token 'legacy-secret-token'
 	option vpn_country 'BM'
 	option server_selection_mode 'manual'
 	option preferred_server_hostname "bm1.nordvpn.com"
@@ -228,16 +228,16 @@ EOF
 
 run_migrator
 
-assert_file_has_line "	option enabled '1'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery normalizes enabled flag'
-assert_file_has_line "	option nordvpn_token 'opkg-secret-token'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves NordVPN token'
-assert_file_has_line "	option vpn_country 'BM'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves selected country'
-assert_file_has_line "	option server_selection_mode 'manual'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves manual mode'
-assert_file_has_line "	option preferred_server_hostname 'bm1.nordvpn.com'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery parses double-quoted hostname'
-assert_file_has_line "	option preferred_server_station 'bm1'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves manual station'
-assert_file_has_line "	option check_cron_schedule '*/5 * * * *'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves cron schedule'
-assert_file_has_line "	option wireguard_mtu '1412'" "$FAKE_UCI_CONFIG_FILE" 'opkg recovery preserves WireGuard MTU'
+assert_file_has_line "	option enabled '1'" "$FAKE_UCI_CONFIG_FILE" 'legacy recovery normalizes enabled flag'
+assert_file_has_line "	option nordvpn_token 'legacy-secret-token'" "$FAKE_UCI_CONFIG_FILE" 'legacy recovery preserves NordVPN token'
+assert_file_has_line "	option vpn_country 'BM'" "$FAKE_UCI_CONFIG_FILE" 'legacy recovery preserves selected country'
+assert_file_has_line "	option server_selection_mode 'manual'" "$FAKE_UCI_CONFIG_FILE" 'legacy recovery preserves manual mode'
+assert_file_has_line "	option preferred_server_hostname 'bm1.nordvpn.com'" "$FAKE_UCI_CONFIG_FILE" 'legacy recovery parses double-quoted hostname'
+assert_file_has_line "	option preferred_server_station 'bm1'" "$FAKE_UCI_CONFIG_FILE" 'legacy recovery preserves manual station'
+assert_file_has_line "	option check_cron_schedule '*/5 * * * *'" "$FAKE_UCI_CONFIG_FILE" 'legacy recovery preserves cron schedule'
+assert_file_has_line "	option wireguard_mtu '1412'" "$FAKE_UCI_CONFIG_FILE" 'legacy recovery preserves WireGuard MTU'
 
-[ ! -e "$FAKE_OPKG_CONFIG_FILE" ] || {
+[ ! -e "$FAKE_LEGACY_CONFIG_FILE" ] || {
 	printf '%s\n' 'FAIL: migrator did not remove recovered nordvpn_easy-opkg file' >&2
 	exit 1
 }
@@ -247,19 +247,19 @@ set_store_value '__section__' 'nordvpn_easy'
 set_store_value 'enabled' '1'
 set_store_value 'nordvpn_token' 'active-secret-token'
 set_store_value 'vpn_country' 'CH'
-cat > "$FAKE_OPKG_CONFIG_FILE" <<'EOF'
+cat > "$FAKE_LEGACY_CONFIG_FILE" <<'EOF'
 config nordvpn_easy 'main'
 	option enabled 'yes'
-	option nordvpn_token 'stale-opkg-token'
+	option nordvpn_token 'stale-legacy-token'
 	option vpn_country 'AT'
 EOF
 
 run_migrator
 
-assert_file_has_line "	option nordvpn_token 'active-secret-token'" "$FAKE_UCI_CONFIG_FILE" 'active config wins over stale opkg token'
-assert_file_has_line "	option vpn_country 'CH'" "$FAKE_UCI_CONFIG_FILE" 'active config wins over stale opkg country'
+assert_file_has_line "	option nordvpn_token 'active-secret-token'" "$FAKE_UCI_CONFIG_FILE" 'active config wins over stale legacy token'
+assert_file_has_line "	option vpn_country 'CH'" "$FAKE_UCI_CONFIG_FILE" 'active config wins over stale legacy country'
 
-[ ! -e "$FAKE_OPKG_CONFIG_FILE" ] || {
+[ ! -e "$FAKE_LEGACY_CONFIG_FILE" ] || {
 	printf '%s\n' 'FAIL: migrator did not remove stale nordvpn_easy-opkg after active config won' >&2
 	exit 1
 }

--- a/tests/nordvpn-easy/test-rpcd.sh
+++ b/tests/nordvpn-easy/test-rpcd.sh
@@ -4,6 +4,7 @@ set -eu
 
 ROOT_DIR="$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)"
 RPCD_SCRIPT="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy"
+ACL_FILE="$ROOT_DIR/openwrt-packages/luci-app-nordvpn-easy/root/usr/share/rpcd/acl.d/luci-app-nordvpn-easy.json"
 LIB_DIR="$ROOT_DIR/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib"
 TMP_DIR="$(mktemp -d)"
 
@@ -20,11 +21,16 @@ printf '%s' "$LIST_JSON" | jq -er '
 	.connect == {} and
 	.disconnect == {} and
 	.reconnect == {} and
+	.reconcile == {} and
 	.refresh_countries.force == "Boolean" and
 	.refresh_servers.country == "String" and
 	.refresh_servers.force == "Boolean" and
 	.diagnostics == {}
 ' >/dev/null
+
+jq -er '
+	."luci-app-nordvpn-easy".write.ubus."nordvpn.easy" | index("reconcile")
+' "$ACL_FILE" >/dev/null
 
 UNKNOWN_JSON="$(printf '{}' | NORDVPN_EASY_LIB_DIR="$LIB_DIR" sh "$RPCD_SCRIPT" call unknown)"
 printf '%s' "$UNKNOWN_JSON" | jq -er '
@@ -132,6 +138,9 @@ case "\$1" in
 	connect)
 		exit 0
 		;;
+	reconcile)
+		exit 0
+		;;
 	check)
 		exit 75
 		;;
@@ -159,6 +168,27 @@ case "$(cat "$TX_CAPTURE")" in
 		;;
 	*)
 		printf '%s\n' 'FAIL: rpc connect should invoke the init connect transaction exactly once' >&2
+		exit 1
+		;;
+esac
+
+RECONCILE_JSON="$(
+	printf '{}' |
+		NORDVPN_EASY_LIB_DIR="$LIB_DIR" \
+		NORDVPN_EASY_INIT_SCRIPT="$TX_INIT" \
+		sh "$RPCD_SCRIPT" call reconcile
+)"
+printf '%s' "$RECONCILE_JSON" | jq -er '
+	.success == true and
+	.action == "reconcile" and
+	.busy == false and
+	.skipped == false
+' >/dev/null
+case "$(tail -n 1 "$TX_CAPTURE")" in
+	reconcile)
+		;;
+	*)
+		printf '%s\n' 'FAIL: rpc reconcile should invoke the init reconcile transaction exactly once' >&2
 		exit 1
 		;;
 esac

--- a/tests/nordvpn-easy/test-service.js
+++ b/tests/nordvpn-easy/test-service.js
@@ -112,6 +112,11 @@ Promise.resolve().then(async function() {
 	assert.deepEqual(call.args, [ 'UY', true ], 'refresh_servers forwards country and force args');
 	assert.deepEqual(payload.args, [ 'UY', true ], 'refresh_servers preserves rpc payload in stdout');
 
+	const reconcileResult = await loaded.service.execService('reconcile');
+	const reconcileCall = loaded.calls[loaded.calls.length - 1];
+	assert.equal(reconcileResult.code, 0, 'reconcile returns normalized success result');
+	assert.equal(reconcileCall.spec.method, 'reconcile', 'reconcile uses the dedicated ubus method');
+
 	loaded.responses.push({
 		code: 75,
 		success: false,


### PR DESCRIPTION
- **Fix config migration and runtime reconciliation**
- **Clarify legacy config migration naming**
- **Fix per-option legacy config recovery**
- **Normalize RPCD action indentation**
- **Normalize test config indentation**
- **Clarify catalog load test invariant**
- **Clarify manual catalog load test**
- **Normalize manager action test doubles & Document deferred catalog rendering**
- **Align config view method blocks**
