### PR TITLE
Reconcile runtime server selection

### DIFF
--- a/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
+++ b/openwrt-packages/nordvpn-easy/files/etc/init.d/nordvpn-easy
@@ -480,8 +480,8 @@ start() {
 	install_hooks || return 1
 
 	RUN_CORE_ACTION_FAILURE_LOG_MODE='info'
-	if ! run_core_action check; then
-		log_service_info 'service: initial check failed; hooks are installed and future cron/hotplug runs will retry'
+	if ! run_core_action reconcile; then
+		log_service_info 'service: initial reconcile failed; hooks are installed and future cron/hotplug runs will retry'
 	fi
 	RUN_CORE_ACTION_FAILURE_LOG_MODE="$previous_failure_log_mode"
 }
@@ -569,7 +569,7 @@ reconcile() {
 	fi
 
 	RUN_CORE_ACTION_FAILURE_LOG_MODE='info'
-	if run_core_action check; then
+	if run_core_action reconcile; then
 		RUN_CORE_ACTION_FAILURE_LOG_MODE="$previous_failure_log_mode"
 		install_hooks
 		return $?
@@ -582,7 +582,7 @@ reconcile() {
 		return "$rc"
 	fi
 
-	log_service_info 'reconcile: health check did not validate the runtime; running reconnect'
+	log_service_info 'reconcile: runtime reconciliation did not validate the runtime; running reconnect'
 	reconnect
 }
 

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -86,10 +86,11 @@ curl_rc_meaning () {
 
 usage () {
   cat <<EOF
-Usage: $0 [check|setup|rotate|refresh_countries|refresh_countries_force|server_catalog|public_ip|public_country|operation_status|vpn_status|status_json|diagnostics_log|run|help] [--config config_file] [extra_args]
+Usage: $0 [check|reconcile|setup|rotate|refresh_countries|refresh_countries_force|server_catalog|public_ip|public_country|operation_status|vpn_status|status_json|diagnostics_log|run|help] [--config config_file] [extra_args]
 
 Commands:
   check   Run one VPN health-check cycle (default)
+  reconcile  Synchronize runtime state with the selected server configuration
   setup   Configure the WireGuard interface and firewall if needed
   rotate  Download a fresh server list and switch server
   refresh_countries  Refresh the cached NordVPN country list if needed
@@ -939,6 +940,10 @@ sync_server_selection () {
   nordvpn_easy_sync_server_selection "$@"
 }
 
+reconcile_action () {
+  nordvpn_easy_reconcile_action "$@"
+}
+
 change_vpn_server () {
   nordvpn_easy_change_vpn_server "$@"
 }
@@ -969,7 +974,7 @@ ACTION_STARTED_AT=''
 
 if [ $# -gt 0 ]; then
   case "$1" in
-    check|setup|rotate|refresh_countries|refresh_countries_force|server_catalog|public_ip|public_country|operation_status|vpn_status|status_json|diagnostics_log|run|help)
+    check|reconcile|setup|rotate|refresh_countries|refresh_countries_force|server_catalog|public_ip|public_country|operation_status|vpn_status|status_json|diagnostics_log|run|help)
       ACTION="$1"
       shift
       ;;
@@ -1137,6 +1142,11 @@ ACTION_RC=0
 case "$ACTION" in
   run|check)
     bootstrap_if_needed && check_once
+    ACTION_RC=$?
+    ;;
+  reconcile)
+    validate_setup_runtime &&
+    reconcile_action
     ACTION_RC=$?
     ;;
   setup)

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
@@ -344,6 +344,13 @@ nordvpn_easy_sync_server_selection() {
 	nordvpn_easy_change_vpn_server reload
 }
 
+nordvpn_easy_reconcile_action() {
+	log 'apply: reconcile action started'
+	nordvpn_easy_bootstrap_if_needed || return 1
+	nordvpn_easy_sync_server_selection || return 1
+	nordvpn_easy_check_once
+}
+
 nordvpn_easy_change_vpn_server() {
 	CURRENT_SERVER=$(nordvpn_easy_current_server_station)
 	local temp_dir=''

--- a/tests/nordvpn-easy/test-actions.sh
+++ b/tests/nordvpn-easy/test-actions.sh
@@ -128,6 +128,11 @@ nordvpn_easy_preferred_server_matches_current() {
 	[ -n "$PREFERRED_SERVER_STATION" ] || return 1
 	[ "$(nordvpn_easy_current_server_station)" = "$PREFERRED_SERVER_STATION" ]
 }
+nordvpn_easy_current_server_matches_recommendations() {
+	jq -e --arg current "$CURRENT_SERVER_VALUE" '
+		[ .[] | select(.station == $current) ] | length > 0
+	' "$SERVER_LIST_FILE" >/dev/null 2>&1
+}
 nordvpn_easy_apply_server_change_runtime() {
 	APPLY_COUNT=$((APPLY_COUNT + 1))
 	if [ "$APPLY_COUNT" -le "$APPLY_FAIL_UNTIL" ]; then
@@ -189,6 +194,20 @@ nordvpn_easy_change_vpn_server reload
 assert_eq '2' "$APPLY_COUNT" 'recommended rotation retries next candidate after apply failure'
 assert_eq '2' "$COMMIT_NETWORK_COUNT" 'recommended rotation commits each tried candidate'
 assert_eq 'it45.nordvpn.com|it456' "$LAST_SET_SERVER" 'recommended rotation lands on second candidate'
+
+SERVER_SELECTION_MODE='auto'
+CURRENT_SERVER_VALUE='bz1'
+APPLY_FAIL_UNTIL=0
+APPLY_COUNT=0
+COMMIT_NETWORK_COUNT=0
+LAST_SET_SERVER=''
+SET_SEQUENCE=''
+
+nordvpn_easy_sync_server_selection
+
+assert_eq '1' "$APPLY_COUNT" 'auto sync rotates when the active server is outside selected country recommendations'
+assert_eq '1' "$COMMIT_NETWORK_COUNT" 'auto sync commits the replacement recommended server once'
+assert_eq 'it12.nordvpn.com|it123' "$LAST_SET_SERVER" 'auto sync lands on a recommended server for the selected country'
 
 APPLY_FAIL_UNTIL=0
 APPLY_COUNT=0
@@ -469,6 +488,30 @@ if [ -f "$(nordvpn_easy_pending_network_reload_marker_path)" ]; then
 	printf '%s\n' 'FAIL: successful pending reload retry should clear marker' >&2
 	exit 1
 fi
+
+VPN_CONFIGURED_RC=0
+BOOTSTRAP_ENABLE_COUNT=0
+BOOTSTRAP_BASE_COUNT=0
+BOOTSTRAP_TRANSPORT_COUNT=0
+BOOTSTRAP_ZONE_COUNT=0
+BOOTSTRAP_PRESENT_COUNT=0
+SERVER_SELECTION_MODE='auto'
+CURRENT_SERVER_VALUE='bz1'
+APPLY_FAIL_UNTIL=0
+APPLY_COUNT=0
+COMMIT_NETWORK_COUNT=0
+LAST_SET_SERVER=''
+PING_COUNT=0
+PING_FAIL_UNTIL=0
+SERVER_ROTATE_THRESHOLD=99
+INTERFACE_RESTART_THRESHOLD=99
+
+nordvpn_easy_reconcile_action
+
+assert_eq '1' "$BOOTSTRAP_ENABLE_COUNT" 'reconcile action bootstraps an already configured interface'
+assert_eq '1' "$APPLY_COUNT" 'reconcile action syncs away from a healthy but mismatched automatic server'
+assert_eq 'it12.nordvpn.com|it123' "$LAST_SET_SERVER" 'reconcile action applies a recommended server for the selected country'
+assert_eq '1' "$PING_COUNT" 'reconcile action health-checks after server selection sync'
 
 NORDVPN_EASY_NETWORK_INIT="$TMP_DIR/network-fail.sh"
 cat > "$NORDVPN_EASY_NETWORK_INIT" <<'EOF'

--- a/tests/nordvpn-easy/test-init-run-core.sh
+++ b/tests/nordvpn-easy/test-init-run-core.sh
@@ -235,6 +235,30 @@ chmod +x "$TMP_DIR/core.sh"
 
 CORE_SCRIPT="$TMP_DIR/core.sh"
 
+cfg_enabled=1
+cfg_nordvpn_token='token-secret'
+cfg_vpn_if='wg0'
+NETWORK_PROTO='wireguard'
+NETWORK_DISABLED=''
+INSTALL_HOOKS_COUNT=0
+CORE_EXIT_RC='0'
+rm -f "$CORE_CAPTURE"
+: > "$INFO_CAPTURE"
+: > "$ERROR_CAPTURE"
+RC=0
+reconcile || RC=$?
+assert_eq '0' "$RC" 'reconcile succeeds through core reconcile when runtime is already configured'
+CORE_ARGS="$(cat "$CORE_CAPTURE")"
+case "$CORE_ARGS" in
+	"reconcile --config $TMP_DIR"/action.*"/nordvpn-easy.reconcile.conf")
+		;;
+	*)
+		printf '%s\n' "FAIL: configured reconcile should run the core reconcile action: $CORE_ARGS" >&2
+		exit 1
+		;;
+esac
+assert_eq '1' "$INSTALL_HOOKS_COUNT" 'configured reconcile installs hooks after successful runtime sync'
+
 : > "$INFO_CAPTURE"
 : > "$ERROR_CAPTURE"
 run_core_action status_json

--- a/tests/nordvpn-easy/test-init-start-soft-fail.sh
+++ b/tests/nordvpn-easy/test-init-start-soft-fail.sh
@@ -38,6 +38,7 @@ eval "$(extract_function start)"
 cfg_enabled=1
 RUN_CORE_ACTION_FAILURE_LOG_MODE=''
 SOFT_FAIL_MODE_CAPTURE="$TMP_DIR/failure-mode.txt"
+CORE_ACTION_CAPTURE="$TMP_DIR/core-action.txt"
 START_OUTPUT_FILE="$TMP_DIR/start-output.txt"
 START_LOG_FILE="$TMP_DIR/start-log.txt"
 
@@ -46,18 +47,20 @@ disable_vpn_runtime() { :; }
 install_hooks() { :; }
 log_service_info() { printf '%s\n' "$1" >> "$START_LOG_FILE"; }
 run_core_action() {
+	printf '%s\n' "$1" > "$CORE_ACTION_CAPTURE"
 	printf '%s\n' "${RUN_CORE_ACTION_FAILURE_LOG_MODE:-unset}" > "$SOFT_FAIL_MODE_CAPTURE"
 	return 1
 }
 
 start >"$START_OUTPUT_FILE"
 
-assert_eq 'info' "$(cat "$SOFT_FAIL_MODE_CAPTURE")" 'start downgrades initial check failures to info logging'
-assert_eq '' "$(cat "$START_OUTPUT_FILE")" 'start does not emit retryable check failure to stdout'
+assert_eq 'reconcile' "$(cat "$CORE_ACTION_CAPTURE")" 'start performs an initial runtime reconcile'
+assert_eq 'info' "$(cat "$SOFT_FAIL_MODE_CAPTURE")" 'start downgrades initial reconcile failures to info logging'
+assert_eq '' "$(cat "$START_OUTPUT_FILE")" 'start does not emit retryable reconcile failure to stdout'
 assert_eq '' "${RUN_CORE_ACTION_FAILURE_LOG_MODE}" 'start restores previous failure log mode'
 
-grep -q 'initial check failed; hooks are installed and future cron/hotplug runs will retry' "$START_LOG_FILE" || {
-	printf '%s\n' 'FAIL: start should log retryable initial check failure' >&2
+grep -q 'initial reconcile failed; hooks are installed and future cron/hotplug runs will retry' "$START_LOG_FILE" || {
+	printf '%s\n' 'FAIL: start should log retryable initial reconcile failure' >&2
 	exit 1
 }
 


### PR DESCRIPTION
Add a dedicated reconcile core action that bootstraps, syncs the active server with saved UCI selection, and health-checks the tunnel. Use it during service start and init reconcile while keeping check lightweight for cron and hotplug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic VPN server selection reconciliation during service startup to ensure runtime configuration aligns with recommended servers.
  * Service now validates and synchronizes runtime state during initialization, automatically adjusting server selection when necessary.

* **Improvements**
  * Enhanced service initialization logging with clearer reconciliation status messages for better transparency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tis24dev/NordVPN-Easy-OpenWrt/pull/64)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->