### PR TITLE
Add auto-reconcile for NordVPN server selection drift

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
@@ -180,9 +180,21 @@ function maybeAutoReconcileSelectionDrift(state, status) {
 		notifyDebugBlock(_('Automatic runtime sync queued'), autoReconcileDebugLines(latestDrift));
 
 		return service.runActions([ 'reconcile' ]).then(function() {
-			state.lastAutoReconcileFailureKey = '';
-			state.lastAutoReconcileFailureAt = 0;
-			return refreshAfterSaveApply(state, true).then(function() {
+			return refreshAfterSaveApply(state, true, { suppressAutoReconcile: true }).then(function() {
+				const remainingDrift = deriveServerSelectionDrift(state, state.currentLocalStatus);
+				let unchangedError;
+
+				if (remainingDrift && remainingDrift.key === latestDrift.key) {
+					unchangedError = new Error(_('Automatic runtime sync completed but server selection is still out of sync.'));
+					state.lastAutoReconcileFailureKey = latestDrift.key;
+					state.lastAutoReconcileFailureAt = Date.now();
+					managerStore.setError(state, unchangedError);
+					service.notifyError(unchangedError);
+					return false;
+				}
+
+				state.lastAutoReconcileFailureKey = '';
+				state.lastAutoReconcileFailureAt = 0;
 				return true;
 			});
 		}).catch(function(err) {
@@ -191,7 +203,7 @@ function maybeAutoReconcileSelectionDrift(state, status) {
 			state.lastAutoReconcileFailureKey = latestDrift.key;
 			state.lastAutoReconcileFailureAt = Date.now();
 			managerStore.setError(state, err);
-			return refreshAfterSaveApply(state, true).then(function() {
+			return refreshAfterSaveApply(state, true, { suppressAutoReconcile: true }).then(function() {
 				service.notifyError(new Error(_('Automatic runtime sync failed: ') + message));
 				return false;
 			});
@@ -617,8 +629,8 @@ function updateLocalStatus(state, options) {
 			state.appliedEnabled = desiredEnabled;
 			state.appliedCountryCode = managerData.normalizeCountryCode(status.selected_country || state.appliedCountryCode);
 			renderLocalStatusSnapshot(state, status);
-			if (localStatusSnapshot.fresh)
-				maybeAutoReconcileSelectionDrift(state, status);
+			if (localStatusSnapshot.fresh && !opts.suppressAutoReconcile)
+				void maybeAutoReconcileSelectionDrift(state, status);
 			return status;
 		}).catch(function(err) {
 			state.currentLocalStatusFresh = false;
@@ -732,11 +744,16 @@ function rememberSavedRuntimeConfig(viewState, state, savedConfig) {
 	state.appliedCountryCode = savedConfig.country;
 }
 
-function refreshAfterSaveApply(state, refreshPublicIp) {
+function refreshAfterSaveApply(state, refreshPublicIp, options) {
+	const opts = options || {};
+
 	state.pendingOperationLabel = '';
 	managerStore.resumePolling(state);
 
-	return updateLocalStatus(state, { force: true }).then(function() {
+	return updateLocalStatus(state, {
+		force: true,
+		suppressAutoReconcile: !!opts.suppressAutoReconcile
+	}).then(function() {
 		if (refreshPublicIp)
 			return updatePublicIp(state, { force: true });
 

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global baseclass, managerData, managerFormat, managerStore, managerUI, service, ui, uci, setTimeout, clearTimeout, E, _ */
+/* global baseclass, managerData, managerFormat, managerStore, managerUI, service, ui, uci, Date, setTimeout, clearTimeout, E, _ */
 'require baseclass';
 'require nordvpn-easy/manager-data as managerData';
 'require nordvpn-easy/manager-format as managerFormat';
@@ -8,6 +8,8 @@
 'require nordvpn-easy/service as service';
 'require ui';
 'require uci';
+
+const AUTO_RECONCILE_RETRY_DELAY_MS = 5 * 60 * 1000;
 
 function formatDebugValue(value, fallback) {
 	const normalized = String(value != null ? value : '').trim();
@@ -81,6 +83,120 @@ function runtimeNeedsReconciliation(runtimeStatus) {
 		return true;
 
 	return !!(runtimeStatus.runtime_disabled || runtimeStatus.interface_disabled || runtimeStatus.runtime_configured === false);
+}
+
+function deriveServerSelectionDrift(state, status) {
+	const runtimeStatus = status || (state && state.currentLocalStatus) || {};
+	const mode = normalizeSelectionMode(runtimeStatus.server_selection_mode || 'auto');
+	const rawSelectedCountry = Object.prototype.hasOwnProperty.call(runtimeStatus, 'selected_country')
+		? runtimeStatus.selected_country
+		: ((state && state.appliedCountryCode) || '');
+	const selectedCountry = managerData.normalizeCountryCode(rawSelectedCountry || '');
+	const currentServerCountry = managerData.normalizeCountryCode(runtimeStatus.current_server_country || '');
+	const preferredStation = String(runtimeStatus.preferred_server_station || '');
+	const currentStation = String(runtimeStatus.current_server_station || '');
+
+	if (mode === 'manual') {
+		if (!preferredStation || !currentStation || preferredStation === currentStation)
+			return null;
+
+		return {
+			key: [ 'manual', preferredStation, currentStation ].join(':'),
+			reason: _('manual server drift'),
+			mode: mode,
+			selectedCountry: selectedCountry,
+			currentServerCountry: currentServerCountry,
+			preferredStation: preferredStation,
+			currentStation: currentStation
+		};
+	}
+
+	if (!selectedCountry || !currentServerCountry || selectedCountry === currentServerCountry)
+		return null;
+
+	return {
+		key: [ 'auto', selectedCountry, currentServerCountry ].join(':'),
+		reason: _('country drift'),
+		mode: mode,
+		selectedCountry: selectedCountry,
+		currentServerCountry: currentServerCountry,
+		preferredStation: preferredStation,
+		currentStation: currentStation
+	};
+}
+
+function autoReconcileIsAllowed(state, status, drift) {
+	const runtimeStatus = status || (state && state.currentLocalStatus) || {};
+
+	return !!drift &&
+		!!state &&
+		!!state.appliedEnabled &&
+		!!runtimeStatus.desired_enabled &&
+		!!runtimeStatus.runtime_configured &&
+		!runtimeStatus.runtime_disabled &&
+		!runtimeStatus.interface_disabled &&
+		!runtimeOperationIsBusy(state, runtimeStatus) &&
+		!managerUI.isDisableRequested(state);
+}
+
+function autoReconcileFailureIsThrottled(state, drift) {
+	const failedAt = Number((state && state.lastAutoReconcileFailureAt) || 0);
+
+	return !!(state && drift &&
+		state.lastAutoReconcileFailureKey === drift.key &&
+		failedAt > 0 &&
+		(Date.now() - failedAt) < AUTO_RECONCILE_RETRY_DELAY_MS);
+}
+
+function autoReconcileDebugLines(drift) {
+	return [
+		_('Reason: %s').format(drift.reason),
+		_('Mode: %s').format(drift.mode),
+		_('Selected country: %s').format(formatDebugValue(drift.selectedCountry)),
+		_('Current server country: %s').format(formatDebugValue(drift.currentServerCountry, _('Unknown'))),
+		_('Preferred station: %s').format(formatDebugValue(drift.preferredStation)),
+		_('Current station: %s').format(formatDebugValue(drift.currentStation, _('Unknown')))
+	];
+}
+
+function maybeAutoReconcileSelectionDrift(state, status) {
+	const runtimeStatus = status || (state && state.currentLocalStatus) || {};
+	const drift = deriveServerSelectionDrift(state, runtimeStatus);
+
+	if (!autoReconcileIsAllowed(state, runtimeStatus, drift) || autoReconcileFailureIsThrottled(state, drift))
+		return Promise.resolve(false);
+
+	return managerStore.runExclusive(state, 'autoReconcile', function() {
+		const latestStatus = state.currentLocalStatus || runtimeStatus;
+		const latestDrift = deriveServerSelectionDrift(state, latestStatus);
+
+		if (!autoReconcileIsAllowed(state, latestStatus, latestDrift) || autoReconcileFailureIsThrottled(state, latestDrift))
+			return Promise.resolve(false);
+
+		state.pendingOperationLabel = 'reconcile';
+		state.currentOperationStatus = 'busy:reconcile';
+		managerStore.setPhase(state, managerStore.PHASES.RUNTIME_BUSY);
+		renderLocalStatusSnapshot(state, latestStatus);
+		notifyDebugBlock(_('Automatic runtime sync queued'), autoReconcileDebugLines(latestDrift));
+
+		return service.runActions([ 'reconcile' ]).then(function() {
+			state.lastAutoReconcileFailureKey = '';
+			state.lastAutoReconcileFailureAt = 0;
+			return refreshAfterSaveApply(state, true).then(function() {
+				return true;
+			});
+		}).catch(function(err) {
+			const message = (err && err.message) ? err.message : String(err);
+
+			state.lastAutoReconcileFailureKey = latestDrift.key;
+			state.lastAutoReconcileFailureAt = Date.now();
+			managerStore.setError(state, err);
+			return refreshAfterSaveApply(state, true).then(function() {
+				service.notifyError(new Error(_('Automatic runtime sync failed: ') + message));
+				return false;
+			});
+		});
+	});
 }
 
 function isLocalStatusPayload(value) {
@@ -500,7 +616,10 @@ function updateLocalStatus(state, options) {
 			state.currentOperationStatus = String(status.operation_status || 'idle');
 			state.appliedEnabled = desiredEnabled;
 			state.appliedCountryCode = managerData.normalizeCountryCode(status.selected_country || state.appliedCountryCode);
-			return renderLocalStatusSnapshot(state, status);
+			renderLocalStatusSnapshot(state, status);
+			if (localStatusSnapshot.fresh)
+				maybeAutoReconcileSelectionDrift(state, status);
+			return status;
 		}).catch(function(err) {
 			state.currentLocalStatusFresh = false;
 			state.currentLocalStatusLastUpdated = 0;
@@ -858,6 +977,8 @@ function handleSaveApply(viewState, state, ev, mode) {
 
 	return baseclass.extend({
 		hasServerSelectionChanged: hasServerSelectionChanged,
+		deriveServerSelectionDrift: deriveServerSelectionDrift,
+		maybeAutoReconcileSelectionDrift: maybeAutoReconcileSelectionDrift,
 		deriveRuntimeActionPlan: deriveRuntimeActionPlan,
 		runtimeOperationIsBusy: runtimeOperationIsBusy,
 		loadServerCatalog: loadServerCatalog,

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-state.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-state.js
@@ -10,6 +10,7 @@ return baseclass.extend({
 	updatePublicIp: managerActions.updatePublicIp,
 	updatePublicCountry: managerActions.updatePublicCountry,
 	updateLocalStatus: managerActions.updateLocalStatus,
+	maybeAutoReconcileSelectionDrift: managerActions.maybeAutoReconcileSelectionDrift,
 	onCountryChanged: managerActions.onCountryChanged,
 	onModeChanged: managerActions.onModeChanged,
 	handleRefreshServerCatalog: managerActions.handleRefreshServerCatalog,

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-store.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-store.js
@@ -31,6 +31,8 @@ function createState() {
 		currentServerCatalog: managerData.emptyServerCatalog(),
 		serverCatalogIndex: {},
 		latestServerCatalogRequestId: 0,
+		lastAutoReconcileFailureKey: '',
+		lastAutoReconcileFailureAt: 0,
 		pollingSuspended: false,
 		pollersStarted: false,
 		lastError: '',
@@ -38,7 +40,8 @@ function createState() {
 			status: null,
 			publicIp: null,
 			publicCountry: null,
-			catalog: null
+			catalog: null,
+			autoReconcile: null
 		}
 	};
 }

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-ui.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-ui.js
@@ -248,6 +248,9 @@ function updateCountryMatchStatus(state) {
 	if (state.currentOperationStatus.indexOf('busy:') === 0) {
 		busyAction = state.currentOperationStatus.substring(5);
 
+		if (busyAction === 'reconcile')
+			return setCountryMatchIndicator('checking', _('Syncing'));
+
 		if (busyAction !== 'refresh_countries' && busyAction !== 'server_catalog' && !actualCountry)
 			return setCountryMatchIndicator('checking', _('Checking'));
 	}
@@ -255,6 +258,9 @@ function updateCountryMatchStatus(state) {
 		if (!actualCountry)
 			return setCountryMatchIndicator('checking', _('Checking'));
 	}
+
+	if (state.pendingOperationLabel === 'reconcile')
+		return setCountryMatchIndicator('checking', _('Syncing'));
 
 	if (!expectedCountry)
 		return setCountryMatchIndicator('automatic', _('Automatic'));

--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/view/nordvpn-easy/config.js
@@ -324,6 +324,8 @@ const TokenValue = form.Value.extend({
 
 			managerUI.renderServerChoices(managerUI.getSelectElement(managerUI.ids.SERVER_FIELD_ID), state.currentServerCatalog, currentPreferredStation);
 			managerActions.renderLocalStatusSnapshot(state, state.currentLocalStatus);
+			if (state.currentLocalStatusFresh)
+				managerActions.maybeAutoReconcileSelectionDrift(state, state.currentLocalStatus);
 			if (!countries.length && !statusPayloadIsBusy(initialStatusPayload))
 				refreshCountriesInBackground(countrySelect, currentCountry);
 

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/core.sh
@@ -179,6 +179,10 @@ current_server_station () {
   nordvpn_easy_current_server_station "$@"
 }
 
+current_server_country () {
+  nordvpn_easy_current_server_country "$@"
+}
+
 set_server_preference_in_uci () {
   nordvpn_easy_set_server_preference_in_uci "$@"
 }

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
@@ -120,6 +120,8 @@ nordvpn_easy_selected_country_code() {
 	nordvpn_easy_require_core_action_helpers resolve_country_filter || return 1
 	resolve_country_filter || return 1
 	[ -n "${RESOLVED_COUNTRY_CODE:-}" ] || return 1
+	# resolve_country_filter currently sets RESOLVED_COUNTRY_CODE from the uppercase cache;
+	# keep normalizing defensively in case future inputs change.
 	nordvpn_easy_normalize_country_code "$RESOLVED_COUNTRY_CODE"
 }
 
@@ -163,6 +165,8 @@ nordvpn_easy_log_server_selection_drift() {
 
 nordvpn_easy_reconcile_explicit_server_selection_drift() {
 	local phase="${1:-healthcheck}"
+	local drift_reason=''
+	local sync_rc=0
 
 	if ! nordvpn_easy_vpn_is_configured; then
 		return 0
@@ -172,8 +176,16 @@ nordvpn_easy_reconcile_explicit_server_selection_drift() {
 		return 0
 	fi
 
+	drift_reason="$NORDVPN_EASY_SELECTION_DRIFT_REASON"
 	log "$phase: server selection drift detected ($NORDVPN_EASY_SELECTION_DRIFT_REASON); synchronizing runtime"
 	nordvpn_easy_sync_server_selection
+	sync_rc=$?
+	if [ "$sync_rc" -eq 0 ]; then
+		return 0
+	fi
+
+	log "WARNING: $phase: server selection drift sync failed (rc=$sync_rc, $drift_reason); continuing health-check recovery"
+	return 0
 }
 
 nordvpn_easy_apply_preferred_server_from_catalog() {

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/actions.sh
@@ -101,6 +101,81 @@ nordvpn_easy_preferred_server_matches_current() {
 	[ "$(nordvpn_easy_current_server_station)" = "$PREFERRED_SERVER_STATION" ]
 }
 
+nordvpn_easy_normalize_country_code() {
+	printf '%s' "${1:-}" | tr '[:lower:]' '[:upper:]'
+}
+
+nordvpn_easy_selected_country_code() {
+	local country_query="${VPN_COUNTRY:-}"
+
+	[ -n "$country_query" ] || return 1
+
+	case "$country_query" in
+		[A-Za-z][A-Za-z])
+			nordvpn_easy_normalize_country_code "$country_query"
+			return 0
+			;;
+	esac
+
+	nordvpn_easy_require_core_action_helpers resolve_country_filter || return 1
+	resolve_country_filter || return 1
+	[ -n "${RESOLVED_COUNTRY_CODE:-}" ] || return 1
+	nordvpn_easy_normalize_country_code "$RESOLVED_COUNTRY_CODE"
+}
+
+nordvpn_easy_server_selection_drift_reason() {
+	local current_station=''
+	local current_country=''
+	local selected_country=''
+
+	NORDVPN_EASY_SELECTION_DRIFT_REASON=''
+
+	current_station="$(nordvpn_easy_current_server_station)"
+
+	if nordvpn_easy_server_selection_is_manual; then
+		[ -n "${PREFERRED_SERVER_STATION:-}" ] || return 1
+		[ -n "$current_station" ] || return 1
+		[ "$current_station" != "$PREFERRED_SERVER_STATION" ] || return 1
+		NORDVPN_EASY_SELECTION_DRIFT_REASON="mode=manual, preferred_station=$PREFERRED_SERVER_STATION, current_station=$current_station, selected_country=${VPN_COUNTRY:-automatic}"
+		return 0
+	fi
+
+	[ -n "${VPN_COUNTRY:-}" ] || return 1
+	selected_country="$(nordvpn_easy_selected_country_code)" || return 1
+	current_country="$(nordvpn_easy_normalize_country_code "$(nordvpn_easy_current_server_country)")"
+	[ -n "$current_country" ] || return 1
+	[ "$current_country" != "$selected_country" ] || return 1
+
+	NORDVPN_EASY_SELECTION_DRIFT_REASON="mode=auto, selected_country=$selected_country, current_server_country=$current_country, current_station=${current_station:-unknown}"
+	return 0
+}
+
+nordvpn_easy_log_server_selection_drift() {
+	local phase="${1:-runtime}"
+
+	if nordvpn_easy_server_selection_drift_reason; then
+		log "$phase: server selection drift detected ($NORDVPN_EASY_SELECTION_DRIFT_REASON)"
+		return 0
+	fi
+
+	return 1
+}
+
+nordvpn_easy_reconcile_explicit_server_selection_drift() {
+	local phase="${1:-healthcheck}"
+
+	if ! nordvpn_easy_vpn_is_configured; then
+		return 0
+	fi
+
+	if ! nordvpn_easy_server_selection_drift_reason; then
+		return 0
+	fi
+
+	log "$phase: server selection drift detected ($NORDVPN_EASY_SELECTION_DRIFT_REASON); synchronizing runtime"
+	nordvpn_easy_sync_server_selection
+}
+
 nordvpn_easy_apply_preferred_server_from_catalog() {
 	nordvpn_easy_find_preferred_server_in_catalog || return 1
 	nordvpn_easy_apply_catalog_server_line_to_uci "$CATALOG_MATCHED_SERVER_LINE" 'preferred'
@@ -347,6 +422,7 @@ nordvpn_easy_sync_server_selection() {
 nordvpn_easy_reconcile_action() {
 	log 'apply: reconcile action started'
 	nordvpn_easy_bootstrap_if_needed || return 1
+	nordvpn_easy_log_server_selection_drift 'reconcile' || true
 	nordvpn_easy_sync_server_selection || return 1
 	nordvpn_easy_check_once
 }
@@ -721,6 +797,7 @@ nordvpn_easy_check_once() {
 	local backoff_steps
 
 	log "healthcheck: starting VPN health-check on interface $VPN_IF (failure_retry_delay=${FAILURE_RETRY_DELAY:-unset}, rotate_threshold=${SERVER_ROTATE_THRESHOLD:-unset}, restart_threshold=${INTERFACE_RESTART_THRESHOLD:-unset}, max_restarts=${max_interface_restarts})"
+	nordvpn_easy_reconcile_explicit_server_selection_drift 'healthcheck' || return 1
 	if ! nordvpn_easy_server_selection_is_manual; then
 		[ -f "$SERVER_LIST_FILE" ] || nordvpn_easy_get_servers_list || true
 	fi

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/common.sh
@@ -235,6 +235,12 @@ nordvpn_easy_current_server_station() {
 	uci -q get "network.${vpn_if}server.nordvpn_station" 2>/dev/null || true
 }
 
+nordvpn_easy_current_server_country() {
+	local vpn_if="${VPN_IF:-wg0}"
+
+	uci -q get "network.${vpn_if}server.nordvpn_country_code" 2>/dev/null || true
+}
+
 nordvpn_easy_set_server_preference_in_uci() {
 	uci set "nordvpn_easy.main.preferred_server_hostname"="$1"
 	uci set "nordvpn_easy.main.preferred_server_station"="$2"

--- a/tests/nordvpn-easy/test-actions.sh
+++ b/tests/nordvpn-easy/test-actions.sh
@@ -460,6 +460,25 @@ nordvpn_easy_check_once
 assert_eq '0' "$APPLY_COUNT" 'health check does not rotate a healthy automatic-country server just because it is outside current recommendations'
 assert_eq '1' "$PING_COUNT" 'health check still validates a healthy automatic-country server'
 
+nordvpn_easy_get_servers_list() { return 1; }
+
+PING_COUNT=0
+PING_FAIL_UNTIL=0
+SERVER_SELECTION_MODE='auto'
+VPN_COUNTRY='IT'
+CURRENT_SERVER_VALUE='bm3'
+CURRENT_COUNTRY_VALUE='BM'
+APPLY_COUNT=0
+COMMIT_NETWORK_COUNT=0
+LAST_SET_SERVER=''
+
+nordvpn_easy_check_once
+
+assert_eq '0' "$APPLY_COUNT" 'health check treats drift sync failure as non-fatal before ping recovery'
+assert_eq '1' "$PING_COUNT" 'health check continues after a selected-country drift sync failure'
+
+nordvpn_easy_get_servers_list() { return 0; }
+
 VPN_CONFIGURED_RC=1
 BOOTSTRAP_REPAIR_RC=0
 BOOTSTRAP_REPAIR_COUNT=0

--- a/tests/nordvpn-easy/test-actions.sh
+++ b/tests/nordvpn-easy/test-actions.sh
@@ -75,6 +75,7 @@ VPN_IF='wg0'
 VPN_CONFIGURED_RC=0
 SERVER_RECOMMENDATIONS_URL_BASE='https://example.invalid/recommendations'
 CURRENT_SERVER_VALUE='it0'
+CURRENT_COUNTRY_VALUE='IT'
 COMMIT_NETWORK_COUNT=0
 COMMIT_PREF_COUNT=0
 APPLY_COUNT=0
@@ -94,6 +95,7 @@ log() { :; }
 fetch_server_catalog() { return 0; }
 nordvpn_easy_require_manual_server_preference() { return 0; }
 nordvpn_easy_current_server_station() { printf '%s\n' "$CURRENT_SERVER_VALUE"; }
+nordvpn_easy_current_server_country() { printf '%s\n' "$CURRENT_COUNTRY_VALUE"; }
 nordvpn_easy_set_vpn_server_in_uci() { LAST_SET_SERVER="$1|$2"; LAST_SET_PUBLIC_KEY="$3"; SET_SEQUENCE="${SET_SEQUENCE}$1|$2;"; return 0; }
 nordvpn_easy_set_server_preference_in_uci() { SAVED_PREFERENCE="$1|$2"; }
 nordvpn_easy_ping_interface() {
@@ -388,6 +390,75 @@ POST_RESTART_DELAY=10
 nordvpn_easy_check_once
 
 assert_eq '1' "$TRY_FALLBACK_COUNT" 'manual health check tries the configured fallback server at the rotation threshold'
+
+TRY_FALLBACK_COUNT=0
+PING_COUNT=0
+PING_FAIL_UNTIL=0
+SERVER_SELECTION_MODE='auto'
+VPN_COUNTRY='IT'
+CURRENT_SERVER_VALUE='bm3'
+CURRENT_COUNTRY_VALUE='BM'
+FALLBACK_SERVER_STATION=''
+APPLY_COUNT=0
+COMMIT_NETWORK_COUNT=0
+LAST_SET_SERVER=''
+SERVER_ROTATE_THRESHOLD=99
+INTERFACE_RESTART_THRESHOLD=99
+
+nordvpn_easy_check_once
+
+assert_eq '1' "$APPLY_COUNT" 'health check reconciles an explicit selected-country drift before ping recovery'
+assert_eq 'it12.nordvpn.com|it123' "$LAST_SET_SERVER" 'health check country drift applies a server for the selected country'
+assert_eq '1' "$PING_COUNT" 'health check validates connectivity after selected-country drift reconciliation'
+
+PING_COUNT=0
+PING_FAIL_UNTIL=0
+SERVER_SELECTION_MODE='manual'
+VPN_COUNTRY='IT'
+CURRENT_SERVER_VALUE='bm3'
+CURRENT_COUNTRY_VALUE='BM'
+PREFERRED_SERVER_HOSTNAME='it12.nordvpn.com'
+PREFERRED_SERVER_STATION='it123'
+FALLBACK_SERVER_STATION=''
+APPLY_COUNT=0
+COMMIT_NETWORK_COUNT=0
+LAST_SET_SERVER=''
+
+nordvpn_easy_check_once
+
+assert_eq '1' "$APPLY_COUNT" 'health check reconciles explicit manual preferred-server drift'
+assert_eq 'it12.nordvpn.com|it123' "$LAST_SET_SERVER" 'health check manual drift applies the preferred server'
+assert_eq '1' "$PING_COUNT" 'health check validates connectivity after manual drift reconciliation'
+
+PING_COUNT=0
+PING_FAIL_UNTIL=0
+SERVER_SELECTION_MODE='auto'
+VPN_COUNTRY='IT'
+CURRENT_SERVER_VALUE='bz1'
+CURRENT_COUNTRY_VALUE='IT'
+APPLY_COUNT=0
+COMMIT_NETWORK_COUNT=0
+LAST_SET_SERVER=''
+
+nordvpn_easy_check_once
+
+assert_eq '0' "$APPLY_COUNT" 'health check does not rotate a healthy same-country server just because it is outside current recommendations'
+assert_eq '1' "$PING_COUNT" 'health check still validates a healthy same-country server'
+
+PING_COUNT=0
+PING_FAIL_UNTIL=0
+SERVER_SELECTION_MODE='auto'
+VPN_COUNTRY=''
+CURRENT_SERVER_VALUE='bz1'
+CURRENT_COUNTRY_VALUE='BM'
+APPLY_COUNT=0
+COMMIT_NETWORK_COUNT=0
+LAST_SET_SERVER=''
+
+nordvpn_easy_check_once
+
+assert_eq '0' "$APPLY_COUNT" 'health check does not rotate a healthy automatic-country server just because it is outside current recommendations'
+assert_eq '1' "$PING_COUNT" 'health check still validates a healthy automatic-country server'
 
 VPN_CONFIGURED_RC=1
 BOOTSTRAP_REPAIR_RC=0

--- a/tests/nordvpn-easy/test-config.js
+++ b/tests/nordvpn-easy/test-config.js
@@ -262,6 +262,7 @@ function loadConfigView(options) {
 		renderLocalStatusSnapshot: [],
 		updateLocalStatus: [],
 		updatePublicIp: [],
+		maybeAutoReconcileSelectionDrift: [],
 		loadServerCatalog: [],
 		updateServerSelectionState: [],
 		onCountryChanged: 0,
@@ -337,6 +338,13 @@ function loadConfigView(options) {
 					options: normalizeValue(updateOptions)
 				});
 				return Promise.resolve();
+			},
+			maybeAutoReconcileSelectionDrift(renderState, status) {
+				calls.maybeAutoReconcileSelectionDrift.push({
+					state: renderState,
+					status: normalizeValue(status)
+				});
+				return Promise.resolve(false);
 			},
 			loadServerCatalog(renderState, country, forceRefresh) {
 				calls.loadServerCatalog.push({

--- a/tests/nordvpn-easy/test-manager-actions.js
+++ b/tests/nordvpn-easy/test-manager-actions.js
@@ -101,6 +101,7 @@ function loadManagerActionsModule(overrides) {
 			return null;
 		},
 		console: console,
+		Date: Date,
 		setTimeout: setTimeout,
 		clearTimeout: clearTimeout,
 		Promise: Promise
@@ -193,6 +194,8 @@ const missingRuntime = {
 const unknownRuntime = {};
 
 assert.equal(typeof managerActions.hasServerSelectionChanged, 'function', 'hasServerSelectionChanged is exported');
+assert.equal(typeof managerActions.deriveServerSelectionDrift, 'function', 'deriveServerSelectionDrift is exported');
+assert.equal(typeof managerActions.maybeAutoReconcileSelectionDrift, 'function', 'maybeAutoReconcileSelectionDrift is exported');
 assert.equal(typeof managerActions.deriveRuntimeActionPlan, 'function', 'deriveRuntimeActionPlan is exported');
 assert.equal(typeof managerActions.renderLocalStatusSnapshot, 'function', 'renderLocalStatusSnapshot is exported');
 assert.equal(managerData.parseEnabledFlag(undefined), false, 'missing enabled option is treated as disabled');
@@ -1267,6 +1270,181 @@ async function testHandleSaveApplyReconcilesDisabledRuntimeAfterSave() {
 	assert.ok(harness.serviceCalls.indexOf('status_json') !== -1, 'reconcile flow refreshes status before choosing runtime action');
 }
 
+async function testAutoReconcileRunsForCountryDrift() {
+	const harness = buildHandleSaveApplyHarness({
+		previousEnabled: true,
+		savedCountry: 'AU',
+		statusPayload: {
+			desired_enabled: true,
+			runtime_disabled: false,
+			interface_disabled: false,
+			runtime_configured: true,
+			operation_status: 'idle',
+			operation_lock_state: 'none',
+			selected_country: 'AU',
+			server_selection_mode: 'auto',
+			current_server_country: 'AU',
+			current_server_station: 'au123'
+		}
+	});
+	const driftStatus = {
+		desired_enabled: true,
+		runtime_disabled: false,
+		interface_disabled: false,
+		runtime_configured: true,
+		operation_status: 'idle',
+		operation_lock_state: 'none',
+		selected_country: 'AU',
+		server_selection_mode: 'auto',
+		current_server_country: 'BM',
+		current_server_station: 'bm3'
+	};
+
+	harness.state.appliedCountryCode = 'AU';
+	harness.state.currentLocalStatus = driftStatus;
+
+	await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, driftStatus);
+
+	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'reconcile' ] ], 'country drift queues exactly one reconcile');
+	assert.equal(harness.state.pendingOperationLabel, '', 'auto reconcile clears the pending label after completion');
+	assert.ok(harness.phaseTransitions.indexOf('runtime_busy') !== -1, 'auto reconcile enters runtime-busy phase');
+	assert.ok(harness.serviceCalls.indexOf('status_json') !== -1, 'auto reconcile refreshes status after completion');
+	assert.ok(harness.serviceCalls.indexOf('public_ip') !== -1, 'auto reconcile refreshes public IP after completion');
+}
+
+async function testAutoReconcileSkipsNonDriftCases() {
+	const cases = [
+		{
+			label: 'busy runtime',
+			status: {
+				desired_enabled: true,
+				runtime_disabled: false,
+				interface_disabled: false,
+				runtime_configured: true,
+				operation_status: 'busy:check',
+				operation_lock_state: 'held',
+				selected_country: 'AU',
+				server_selection_mode: 'auto',
+				current_server_country: 'BM',
+				current_server_station: 'bm3'
+			}
+		},
+		{
+			label: 'disabled runtime',
+			state: { appliedEnabled: false },
+			status: {
+				desired_enabled: false,
+				runtime_disabled: true,
+				interface_disabled: true,
+				runtime_configured: true,
+				operation_status: 'idle',
+				selected_country: 'AU',
+				server_selection_mode: 'auto',
+				current_server_country: 'BM',
+				current_server_station: 'bm3'
+			}
+		},
+		{
+			label: 'automatic country',
+			status: {
+				desired_enabled: true,
+				runtime_disabled: false,
+				interface_disabled: false,
+				runtime_configured: true,
+				operation_status: 'idle',
+				selected_country: '',
+				server_selection_mode: 'auto',
+				current_server_country: 'BM',
+				current_server_station: 'bm3'
+			}
+		},
+		{
+			label: 'aligned country',
+			status: {
+				desired_enabled: true,
+				runtime_disabled: false,
+				interface_disabled: false,
+				runtime_configured: true,
+				operation_status: 'idle',
+				selected_country: 'AU',
+				server_selection_mode: 'auto',
+				current_server_country: 'AU',
+				current_server_station: 'au123'
+			}
+		},
+		{
+			label: 'manual missing preference',
+			status: {
+				desired_enabled: true,
+				runtime_disabled: false,
+				interface_disabled: false,
+				runtime_configured: true,
+				operation_status: 'idle',
+				selected_country: 'AU',
+				server_selection_mode: 'manual',
+				preferred_server_station: '',
+				current_server_station: 'au123'
+			}
+		}
+	];
+
+	for (const testCase of cases) {
+		const harness = buildHandleSaveApplyHarness({
+			previousEnabled: true,
+			savedCountry: 'AU',
+			state: Object.assign({ appliedEnabled: true, appliedCountryCode: 'AU' }, testCase.state || {})
+		});
+
+		harness.state.currentLocalStatus = testCase.status;
+		await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, testCase.status);
+		assert.deepEqual(normalizeValue(harness.runtimeActions), [], 'auto reconcile skips ' + testCase.label);
+	}
+}
+
+async function testAutoReconcileThrottlesRepeatedFailures() {
+	const runError = new Error('reconcile exploded');
+	const harness = buildHandleSaveApplyHarness({
+		previousEnabled: true,
+		savedCountry: 'AU',
+		runActionsReject: runError,
+		statusPayload: {
+			desired_enabled: true,
+			runtime_disabled: false,
+			interface_disabled: false,
+			runtime_configured: true,
+			operation_status: 'idle',
+			operation_lock_state: 'none',
+			selected_country: 'AU',
+			server_selection_mode: 'auto',
+			current_server_country: 'BM',
+			current_server_station: 'bm3'
+		}
+	});
+	const driftStatus = {
+		desired_enabled: true,
+		runtime_disabled: false,
+		interface_disabled: false,
+		runtime_configured: true,
+		operation_status: 'idle',
+		operation_lock_state: 'none',
+		selected_country: 'AU',
+		server_selection_mode: 'auto',
+		current_server_country: 'BM',
+		current_server_station: 'bm3'
+	};
+
+	harness.state.appliedCountryCode = 'AU';
+	harness.state.currentLocalStatus = driftStatus;
+
+	await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, driftStatus);
+	await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, driftStatus);
+
+	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'reconcile' ] ], 'failed auto reconcile is throttled for the same drift');
+	assert.match(harness.notifications[harness.notifications.length - 1].message, /Automatic runtime sync failed: reconcile exploded/, 'auto reconcile failure is reported once');
+	assert.equal(harness.notifications.length, 1, 'throttled auto reconcile does not repeat notifications');
+	assert.equal(harness.state.lastAutoReconcileFailureKey, 'auto:AU:BM', 'throttle records the drift key');
+}
+
 Promise.resolve().then(async function() {
 	await testUpdateLocalStatusMarksSnapshotsStaleOnFailedResponse();
 	await testUpdateLocalStatusMarksSnapshotsStaleOnRejectedExec();
@@ -1281,6 +1459,9 @@ Promise.resolve().then(async function() {
 	await testHandleSaveApplyClearsBusyStateWhenPostApplySyncFails();
 	await testHandleSaveApplyAutoModeClearsManualSelectionAndReconnects();
 	await testHandleSaveApplyReconcilesDisabledRuntimeAfterSave();
+	await testAutoReconcileRunsForCountryDrift();
+	await testAutoReconcileSkipsNonDriftCases();
+	await testAutoReconcileThrottlesRepeatedFailures();
 	console.log('test-manager-actions.js: ok');
 }).catch(function(err) {
 	console.error(err);

--- a/tests/nordvpn-easy/test-manager-actions.js
+++ b/tests/nordvpn-easy/test-manager-actions.js
@@ -1312,6 +1312,47 @@ async function testAutoReconcileRunsForCountryDrift() {
 	assert.ok(harness.serviceCalls.indexOf('public_ip') !== -1, 'auto reconcile refreshes public IP after completion');
 }
 
+async function testAutoReconcileThrottlesSuccessfulNoChange() {
+	const harness = buildHandleSaveApplyHarness({
+		previousEnabled: true,
+		savedCountry: 'AU',
+		statusPayload: {
+			desired_enabled: true,
+			runtime_disabled: false,
+			interface_disabled: false,
+			runtime_configured: true,
+			operation_status: 'idle',
+			operation_lock_state: 'none',
+			selected_country: 'AU',
+			server_selection_mode: 'auto',
+			current_server_country: 'BM',
+			current_server_station: 'bm3'
+		}
+	});
+	const driftStatus = {
+		desired_enabled: true,
+		runtime_disabled: false,
+		interface_disabled: false,
+		runtime_configured: true,
+		operation_status: 'idle',
+		operation_lock_state: 'none',
+		selected_country: 'AU',
+		server_selection_mode: 'auto',
+		current_server_country: 'BM',
+		current_server_station: 'bm3'
+	};
+
+	harness.state.appliedCountryCode = 'AU';
+	harness.state.currentLocalStatus = driftStatus;
+
+	await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, driftStatus);
+	await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, harness.state.currentLocalStatus);
+
+	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'reconcile' ] ], 'successful reconcile that leaves the same drift is throttled');
+	assert.equal(harness.state.lastAutoReconcileFailureKey, 'auto:AU:BM', 'unchanged success records the drift key');
+	assert.match(harness.notifications[harness.notifications.length - 1].message, /still out of sync/, 'unchanged success reports a readable sync error');
+}
+
 async function testAutoReconcileSkipsNonDriftCases() {
 	const cases = [
 		{
@@ -1460,6 +1501,7 @@ Promise.resolve().then(async function() {
 	await testHandleSaveApplyAutoModeClearsManualSelectionAndReconnects();
 	await testHandleSaveApplyReconcilesDisabledRuntimeAfterSave();
 	await testAutoReconcileRunsForCountryDrift();
+	await testAutoReconcileThrottlesSuccessfulNoChange();
 	await testAutoReconcileSkipsNonDriftCases();
 	await testAutoReconcileThrottlesRepeatedFailures();
 	console.log('test-manager-actions.js: ok');


### PR DESCRIPTION
Detect when the saved NordVPN country or manual server selection no longer matches the active WireGuard peer and automatically queue a reconcile from LuCI.

Also updates health checks to fix only explicit country/manual-server drift, avoids noisy recommendation-only rotations, shows Syncing during reconcile, and adds JS/shell coverage for drift, no-op, and throttle cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic VPN server synchronization: The app now detects when your VPN server drifts from your configured preferences and automatically reconnects to the correct server.
  * Intelligent throttling prevents repeated sync attempts for the same issue within 5 minutes, reducing unnecessary reconnections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tis24dev/NordVPN-Easy-OpenWrt/pull/66)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->