### PR TITLE
Fix runtime server selection drift

### DIFF
--- a/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
+++ b/openwrt-packages/luci-app-nordvpn-easy/htdocs/luci-static/resources/nordvpn-easy/manager-actions.js
@@ -85,6 +85,42 @@ function runtimeNeedsReconciliation(runtimeStatus) {
 	return !!(runtimeStatus.runtime_disabled || runtimeStatus.interface_disabled || runtimeStatus.runtime_configured === false);
 }
 
+function deriveSavedServerSelectionDrift(mode, country, preferredStation, runtimeStatus) {
+	const currentMode = normalizeSelectionMode(mode);
+	const selectedCountry = managerData.normalizeCountryCode(country || '');
+	const currentServerCountry = managerData.normalizeCountryCode((runtimeStatus && runtimeStatus.current_server_country) || '');
+	const savedPreferredStation = String(preferredStation || '');
+	const currentStation = String((runtimeStatus && runtimeStatus.current_server_station) || '');
+
+	if (currentMode === 'manual') {
+		if (!savedPreferredStation || !currentStation || savedPreferredStation === currentStation)
+			return null;
+
+		return {
+			key: [ 'manual', savedPreferredStation, currentStation ].join(':'),
+			reason: _('manual server drift'),
+			mode: currentMode,
+			selectedCountry: selectedCountry,
+			currentServerCountry: currentServerCountry,
+			preferredStation: savedPreferredStation,
+			currentStation: currentStation
+		};
+	}
+
+	if (!selectedCountry || !currentServerCountry || selectedCountry === currentServerCountry)
+		return null;
+
+	return {
+		key: [ 'auto', selectedCountry, currentServerCountry ].join(':'),
+		reason: _('country drift'),
+		mode: currentMode,
+		selectedCountry: selectedCountry,
+		currentServerCountry: currentServerCountry,
+		preferredStation: savedPreferredStation,
+		currentStation: currentStation
+	};
+}
+
 function deriveServerSelectionDrift(state, status) {
 	const runtimeStatus = status || (state && state.currentLocalStatus) || {};
 	const mode = normalizeSelectionMode(runtimeStatus.server_selection_mode || 'auto');
@@ -173,13 +209,13 @@ function maybeAutoReconcileSelectionDrift(state, status) {
 		if (!autoReconcileIsAllowed(state, latestStatus, latestDrift) || autoReconcileFailureIsThrottled(state, latestDrift))
 			return Promise.resolve(false);
 
-		state.pendingOperationLabel = 'reconcile';
-		state.currentOperationStatus = 'busy:reconcile';
+		state.pendingOperationLabel = 'reconnect';
+		state.currentOperationStatus = 'busy:reconnect';
 		managerStore.setPhase(state, managerStore.PHASES.RUNTIME_BUSY);
 		renderLocalStatusSnapshot(state, latestStatus);
 		notifyDebugBlock(_('Automatic runtime sync queued'), autoReconcileDebugLines(latestDrift));
 
-		return service.runActions([ 'reconcile' ]).then(function() {
+		return service.runActions([ 'reconnect' ]).then(function() {
 			return refreshAfterSaveApply(state, true, { suppressAutoReconcile: true }).then(function() {
 				const remainingDrift = deriveServerSelectionDrift(state, state.currentLocalStatus);
 				let unchangedError;
@@ -237,6 +273,12 @@ function deriveRuntimeActionPlan(previousEnabled, enabled, previousCountry, coun
 		previousPreferredStation,
 		preferredStation
 	);
+	const serverSelectionDrift = currentEnabled && deriveSavedServerSelectionDrift(
+		currentMode,
+		country,
+		preferredStation,
+		runtimeStatus
+	);
 	const runtimeReconciliationRequired = currentEnabled && runtimeNeedsReconciliation(runtimeStatus);
 	const plan = {
 		actions: [],
@@ -256,7 +298,7 @@ function deriveRuntimeActionPlan(previousEnabled, enabled, previousCountry, coun
 		return plan;
 	}
 
-	if (currentEnabled && serverSelectionChanged) {
+	if (currentEnabled && (serverSelectionChanged || serverSelectionDrift)) {
 		plan.actions = [ 'reconnect' ];
 		plan.successMessage = currentMode === 'manual'
 			? _('NordVPN Easy restarted and synchronized the selected manual server.')

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/wireguard.sh
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/nordvpn-easy/lib/wireguard.sh
@@ -484,8 +484,13 @@ nordvpn_easy_current_server_matches_recommendations() {
 
 	[ -n "$CURRENT_SERVER" ] || return 1
 
-	jq -e --arg current "$CURRENT_SERVER" '
-		[ .[] | select(.station == $current) ] | length > 0
+	jq -e --arg current "$CURRENT_SERVER" --arg country "${RESOLVED_COUNTRY_CODE:-}" '
+		[
+			.[] | select(
+				(.station == $current) and
+				($country == "" or ((.locations[0].country.code // "") == $country))
+			)
+		] | length > 0
 	' "$SERVER_LIST_FILE" >/dev/null 2>&1
 }
 

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy
@@ -6,6 +6,7 @@ UCI_SECTION='main'
 LIB_DIR="${NORDVPN_EASY_LIB_DIR:-/usr/libexec/nordvpn-easy/lib}"
 LOCK_DIR="${NORDVPN_EASY_LOCK_DIR:-/tmp/nordvpn-easy.lock}"
 NORDVPN_EASY_RC_BUSY="${NORDVPN_EASY_RC_BUSY:-75}"
+AUTO_RECONCILE_COOLDOWN_SECONDS="${NORDVPN_EASY_RPC_AUTO_RECONCILE_COOLDOWN_SECONDS:-300}"
 
 # shellcheck disable=SC1090
 . "${LIB_DIR}/config-context.sh" || exit 1
@@ -110,8 +111,112 @@ rpc_load_runtime_context_readonly() {
 	CONFIG_CONTEXT_SOURCE="uci:${UCI_CONFIG}.${UCI_SECTION}:readonly"
 }
 
+rpc_log_notice() {
+	if command -v logger >/dev/null 2>&1; then
+		logger -t nordvpn-easy "$*"
+	fi
+}
+
+rpc_normalize_country_code() {
+	printf '%s' "${1:-}" | tr '[:lower:]' '[:upper:]'
+}
+
+rpc_runtime_operation_is_busy() {
+	nordvpn_easy_load_lock_metadata "$LOCK_DIR"
+	[ "${OPERATION_LOCK_STATE:-none}" = 'held' ]
+}
+
+rpc_current_server_station() {
+	uci -q get "network.${VPN_IF:-wg0}server.nordvpn_station" 2>/dev/null || true
+}
+
+rpc_current_server_country() {
+	uci -q get "network.${VPN_IF:-wg0}server.nordvpn_country_code" 2>/dev/null || true
+}
+
+rpc_status_selection_drift_reason() {
+	local current_station=''
+	local current_country=''
+	local selected_country=''
+
+	RPC_STATUS_SELECTION_DRIFT_KEY=''
+	RPC_STATUS_SELECTION_DRIFT_REASON=''
+
+	[ "${DESIRED_ENABLED:-0}" = '1' ] || return 1
+	rpc_runtime_operation_is_busy && return 1
+
+	current_station="$(rpc_current_server_station)"
+
+	if [ "${SERVER_SELECTION_MODE:-auto}" = 'manual' ]; then
+		[ -n "${PREFERRED_SERVER_STATION:-}" ] || return 1
+		[ -n "$current_station" ] || return 1
+		[ "$current_station" != "$PREFERRED_SERVER_STATION" ] || return 1
+		RPC_STATUS_SELECTION_DRIFT_KEY="manual:${PREFERRED_SERVER_STATION}:${current_station}"
+		RPC_STATUS_SELECTION_DRIFT_REASON="mode=manual, preferred_station=$PREFERRED_SERVER_STATION, current_station=$current_station, selected_country=${VPN_COUNTRY:-automatic}"
+		return 0
+	fi
+
+	[ -n "${VPN_COUNTRY:-}" ] || return 1
+	selected_country="$(rpc_normalize_country_code "$VPN_COUNTRY")"
+	current_country="$(rpc_normalize_country_code "$(rpc_current_server_country)")"
+	[ -n "$current_country" ] || return 1
+	[ "$current_country" != "$selected_country" ] || return 1
+
+	RPC_STATUS_SELECTION_DRIFT_KEY="auto:${selected_country}:${current_country}"
+	RPC_STATUS_SELECTION_DRIFT_REASON="mode=auto, selected_country=$selected_country, current_server_country=$current_country, current_station=${current_station:-unknown}"
+	return 0
+}
+
+rpc_status_auto_reconcile_is_throttled() {
+	local key_file="$NORDVPN_EASY_RUN_DIR/status_auto_reconcile.key"
+	local ts_file="$NORDVPN_EASY_RUN_DIR/status_auto_reconcile.ts"
+	local previous_key=''
+	local previous_ts=''
+	local now=''
+
+	[ -n "${RPC_STATUS_SELECTION_DRIFT_KEY:-}" ] || return 1
+	previous_key="$(sed -n '1p' "$key_file" 2>/dev/null || true)"
+	previous_ts="$(sed -n '1p' "$ts_file" 2>/dev/null || true)"
+	[ "$previous_key" = "$RPC_STATUS_SELECTION_DRIFT_KEY" ] || return 1
+	case "$previous_ts" in
+		''|*[!0-9]*)
+			return 1
+			;;
+	esac
+	now="$(date +%s 2>/dev/null || printf '%s' '0')"
+	[ $((now - previous_ts)) -lt "$AUTO_RECONCILE_COOLDOWN_SECONDS" ]
+}
+
+rpc_record_status_auto_reconcile_attempt() {
+	local key_file="$NORDVPN_EASY_RUN_DIR/status_auto_reconcile.key"
+	local ts_file="$NORDVPN_EASY_RUN_DIR/status_auto_reconcile.ts"
+	local now=''
+
+	mkdir -p "$NORDVPN_EASY_RUN_DIR" || return 0
+	now="$(date +%s 2>/dev/null || printf '%s' '0')"
+	printf '%s\n' "$RPC_STATUS_SELECTION_DRIFT_KEY" > "$key_file" 2>/dev/null || true
+	printf '%s\n' "$now" > "$ts_file" 2>/dev/null || true
+}
+
+rpc_maybe_auto_reconcile_status_drift() {
+	if ! rpc_status_selection_drift_reason; then
+		return 0
+	fi
+
+	if rpc_status_auto_reconcile_is_throttled; then
+		return 0
+	fi
+
+	rpc_record_status_auto_reconcile_attempt
+	rpc_log_notice "rpc status: server selection drift detected ($RPC_STATUS_SELECTION_DRIFT_REASON); queued reconcile"
+	(
+		"$INIT_SCRIPT" reconcile </dev/null >/dev/null 2>&1
+	) &
+}
+
 rpc_status() {
 	if rpc_load_runtime_context_readonly >/dev/null 2>&1; then
+		rpc_maybe_auto_reconcile_status_drift
 		if nordvpn_easy_write_status_cache >/dev/null 2>&1; then
 			nordvpn_easy_emit_cached_status_json
 		else

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy
@@ -7,6 +7,7 @@ LIB_DIR="${NORDVPN_EASY_LIB_DIR:-/usr/libexec/nordvpn-easy/lib}"
 LOCK_DIR="${NORDVPN_EASY_LOCK_DIR:-/tmp/nordvpn-easy.lock}"
 NORDVPN_EASY_RC_BUSY="${NORDVPN_EASY_RC_BUSY:-75}"
 AUTO_RECONCILE_COOLDOWN_SECONDS="${NORDVPN_EASY_RPC_AUTO_RECONCILE_COOLDOWN_SECONDS:-300}"
+AUTO_RECONCILE_THROTTLE_LOG_SECONDS="${NORDVPN_EASY_RPC_AUTO_RECONCILE_THROTTLE_LOG_SECONDS:-60}"
 
 # shellcheck disable=SC1090
 . "${LIB_DIR}/config-context.sh" || exit 1
@@ -170,12 +171,22 @@ rpc_status_selection_drift_reason() {
 rpc_status_auto_reconcile_is_throttled() {
 	local key_file="$NORDVPN_EASY_RUN_DIR/status_auto_reconcile.key"
 	local ts_file="$NORDVPN_EASY_RUN_DIR/status_auto_reconcile.ts"
+	local log_key_file="$NORDVPN_EASY_RUN_DIR/status_auto_reconcile_throttle_log.key"
+	local log_ts_file="$NORDVPN_EASY_RUN_DIR/status_auto_reconcile_throttle_log.ts"
 	local previous_key=''
 	local previous_ts=''
+	local previous_log_key=''
+	local previous_log_ts=''
 	local now=''
 	local age_seconds=0
+	local log_age_seconds=0
 
 	[ -n "${RPC_STATUS_SELECTION_DRIFT_KEY:-}" ] || return 1
+	case "$AUTO_RECONCILE_THROTTLE_LOG_SECONDS" in
+		''|*[!0-9]*)
+			AUTO_RECONCILE_THROTTLE_LOG_SECONDS='60'
+			;;
+	esac
 	previous_key="$(sed -n '1p' "$key_file" 2>/dev/null || true)"
 	previous_ts="$(sed -n '1p' "$ts_file" 2>/dev/null || true)"
 	[ "$previous_key" = "$RPC_STATUS_SELECTION_DRIFT_KEY" ] || return 1
@@ -187,7 +198,22 @@ rpc_status_auto_reconcile_is_throttled() {
 	now="$(date +%s 2>/dev/null || printf '%s' '0')"
 	age_seconds=$((now - previous_ts))
 	if [ "$age_seconds" -lt "$AUTO_RECONCILE_COOLDOWN_SECONDS" ]; then
+		previous_log_key="$(sed -n '1p' "$log_key_file" 2>/dev/null || true)"
+		previous_log_ts="$(sed -n '1p' "$log_ts_file" 2>/dev/null || true)"
+		case "$previous_log_ts" in
+			''|*[!0-9]*)
+				previous_log_ts=''
+				;;
+		esac
+		if [ "$previous_log_key" = "$RPC_STATUS_SELECTION_DRIFT_KEY" ] && [ -n "$previous_log_ts" ]; then
+			log_age_seconds=$((now - previous_log_ts))
+			[ "$log_age_seconds" -lt "$AUTO_RECONCILE_THROTTLE_LOG_SECONDS" ] && return 0
+		fi
+
 		rpc_log_notice "rpc status: server selection drift still throttled (key=$RPC_STATUS_SELECTION_DRIFT_KEY, age_seconds=$age_seconds, cooldown_seconds=$AUTO_RECONCILE_COOLDOWN_SECONDS)"
+		mkdir -p "$NORDVPN_EASY_RUN_DIR" || return 0
+		printf '%s\n' "$RPC_STATUS_SELECTION_DRIFT_KEY" > "$log_key_file" 2>/dev/null || true
+		printf '%s\n' "$now" > "$log_ts_file" 2>/dev/null || true
 		return 0
 	fi
 

--- a/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy
+++ b/openwrt-packages/nordvpn-easy/files/usr/libexec/rpcd/nordvpn.easy
@@ -173,6 +173,7 @@ rpc_status_auto_reconcile_is_throttled() {
 	local previous_key=''
 	local previous_ts=''
 	local now=''
+	local age_seconds=0
 
 	[ -n "${RPC_STATUS_SELECTION_DRIFT_KEY:-}" ] || return 1
 	previous_key="$(sed -n '1p' "$key_file" 2>/dev/null || true)"
@@ -184,7 +185,13 @@ rpc_status_auto_reconcile_is_throttled() {
 			;;
 	esac
 	now="$(date +%s 2>/dev/null || printf '%s' '0')"
-	[ $((now - previous_ts)) -lt "$AUTO_RECONCILE_COOLDOWN_SECONDS" ]
+	age_seconds=$((now - previous_ts))
+	if [ "$age_seconds" -lt "$AUTO_RECONCILE_COOLDOWN_SECONDS" ]; then
+		rpc_log_notice "rpc status: server selection drift still throttled (key=$RPC_STATUS_SELECTION_DRIFT_KEY, age_seconds=$age_seconds, cooldown_seconds=$AUTO_RECONCILE_COOLDOWN_SECONDS)"
+		return 0
+	fi
+
+	return 1
 }
 
 rpc_record_status_auto_reconcile_attempt() {
@@ -208,9 +215,9 @@ rpc_maybe_auto_reconcile_status_drift() {
 	fi
 
 	rpc_record_status_auto_reconcile_attempt
-	rpc_log_notice "rpc status: server selection drift detected ($RPC_STATUS_SELECTION_DRIFT_REASON); queued reconcile"
+	rpc_log_notice "rpc status: server selection drift detected ($RPC_STATUS_SELECTION_DRIFT_REASON); queued reconnect"
 	(
-		"$INIT_SCRIPT" reconcile </dev/null >/dev/null 2>&1
+		"$INIT_SCRIPT" reconnect </dev/null >/dev/null 2>&1
 	) &
 }
 

--- a/tests/nordvpn-easy/test-manager-actions.js
+++ b/tests/nordvpn-easy/test-manager-actions.js
@@ -287,6 +287,32 @@ assert.deepEqual(
 );
 
 assert.deepEqual(
+	normalizeValue(managerActions.deriveRuntimeActionPlan(true, true, 'UY', 'UY', 'auto', 'auto', '', '', Object.assign({}, healthyRuntime, {
+		current_server_country: 'AT',
+		current_server_station: 'at123'
+	}))),
+	{
+		actions: [ 'reconnect' ],
+		successMessage: 'NordVPN Easy restarted and synchronized the automatic server selection.',
+		serverSelectionChanged: false
+	},
+	'unchanged country with runtime country drift uses transactional reconnect'
+);
+
+assert.deepEqual(
+	normalizeValue(managerActions.deriveRuntimeActionPlan(true, true, 'UY', 'UY', 'manual', 'manual', 'uy123', 'uy123', Object.assign({}, healthyRuntime, {
+		current_server_country: 'UY',
+		current_server_station: 'uy999'
+	}))),
+	{
+		actions: [ 'reconnect' ],
+		successMessage: 'NordVPN Easy restarted and synchronized the selected manual server.',
+		serverSelectionChanged: false
+	},
+	'unchanged manual preference with runtime station drift uses transactional reconnect'
+);
+
+assert.deepEqual(
 	normalizeValue(managerActions.deriveRuntimeActionPlan(true, true, 'UY', 'UY', 'auto', 'auto', '', '', disabledRuntime)),
 	{
 		actions: [ 'reconcile' ],
@@ -1305,7 +1331,7 @@ async function testAutoReconcileRunsForCountryDrift() {
 
 	await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, driftStatus);
 
-	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'reconcile' ] ], 'country drift queues exactly one reconcile');
+	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'reconnect' ] ], 'country drift queues exactly one reconnect');
 	assert.equal(harness.state.pendingOperationLabel, '', 'auto reconcile clears the pending label after completion');
 	assert.ok(harness.phaseTransitions.indexOf('runtime_busy') !== -1, 'auto reconcile enters runtime-busy phase');
 	assert.ok(harness.serviceCalls.indexOf('status_json') !== -1, 'auto reconcile refreshes status after completion');
@@ -1348,7 +1374,7 @@ async function testAutoReconcileThrottlesSuccessfulNoChange() {
 	await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, driftStatus);
 	await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, harness.state.currentLocalStatus);
 
-	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'reconcile' ] ], 'successful reconcile that leaves the same drift is throttled');
+	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'reconnect' ] ], 'successful reconnect that leaves the same drift is throttled');
 	assert.equal(harness.state.lastAutoReconcileFailureKey, 'auto:AU:BM', 'unchanged success records the drift key');
 	assert.match(harness.notifications[harness.notifications.length - 1].message, /still out of sync/, 'unchanged success reports a readable sync error');
 }
@@ -1443,7 +1469,7 @@ async function testAutoReconcileSkipsNonDriftCases() {
 }
 
 async function testAutoReconcileThrottlesRepeatedFailures() {
-	const runError = new Error('reconcile exploded');
+	const runError = new Error('reconnect exploded');
 	const harness = buildHandleSaveApplyHarness({
 		previousEnabled: true,
 		savedCountry: 'AU',
@@ -1480,8 +1506,8 @@ async function testAutoReconcileThrottlesRepeatedFailures() {
 	await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, driftStatus);
 	await harness.actions.maybeAutoReconcileSelectionDrift(harness.state, driftStatus);
 
-	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'reconcile' ] ], 'failed auto reconcile is throttled for the same drift');
-	assert.match(harness.notifications[harness.notifications.length - 1].message, /Automatic runtime sync failed: reconcile exploded/, 'auto reconcile failure is reported once');
+	assert.deepEqual(normalizeValue(harness.runtimeActions), [ [ 'reconnect' ] ], 'failed auto reconnect is throttled for the same drift');
+	assert.match(harness.notifications[harness.notifications.length - 1].message, /Automatic runtime sync failed: reconnect exploded/, 'auto reconnect failure is reported once');
 	assert.equal(harness.notifications.length, 1, 'throttled auto reconcile does not repeat notifications');
 	assert.equal(harness.state.lastAutoReconcileFailureKey, 'auto:AU:BM', 'throttle records the drift key');
 }

--- a/tests/nordvpn-easy/test-rpcd.sh
+++ b/tests/nordvpn-easy/test-rpcd.sh
@@ -215,4 +215,90 @@ printf '%s' "$BUSY_JSON" | jq -er '
 	(.message | contains("operation busy"))
 ' >/dev/null
 
+STATUS_BIN_DIR="$TMP_DIR/status-bin"
+STATUS_INIT="$TMP_DIR/init-status"
+STATUS_CAPTURE="$TMP_DIR/status-reconcile-calls"
+STATUS_RUN_DIR="$TMP_DIR/status-run"
+mkdir -p "$STATUS_BIN_DIR" "$STATUS_RUN_DIR"
+cat > "$STATUS_BIN_DIR/uci" <<'EOF'
+#!/bin/sh
+if [ "$1" = 'show' ] && [ "$2" = 'firewall' ]; then
+	exit 0
+fi
+if [ "$1" = '-q' ] && [ "$2" = 'get' ]; then
+	case "$3" in
+		nordvpn_easy.main.enabled) printf '%s\n' '1' ;;
+		nordvpn_easy.main.vpn_country) printf '%s\n' "${FAKE_VPN_COUNTRY:-BO}" ;;
+		nordvpn_easy.main.server_selection_mode) printf '%s\n' "${FAKE_SELECTION_MODE:-auto}" ;;
+		nordvpn_easy.main.vpn_if) printf '%s\n' 'wg0' ;;
+		network.wg0.proto) printf '%s\n' 'wireguard' ;;
+		network.wg0server.nordvpn_station) printf '%s\n' "${FAKE_CURRENT_STATION:-45.248.77.163}" ;;
+		network.wg0server.nordvpn_country_code) printf '%s\n' "${FAKE_CURRENT_COUNTRY:-AU}" ;;
+		network.wg0server.nordvpn_hostname) printf '%s\n' 'au742.nordvpn.com' ;;
+		network.wg0server.endpoint_host) printf '%s\n' 'au742.nordvpn.com' ;;
+		network.wg0server.nordvpn_city) printf '%s\n' 'Brisbane' ;;
+		network.wg0server.nordvpn_load) printf '%s\n' '17' ;;
+		network.wg0server.endpoint_port) printf '%s\n' '51820' ;;
+		network.wg0server.persistent_keepalive) printf '%s\n' '15' ;;
+		*)
+			exit 1
+			;;
+	esac
+	exit 0
+fi
+exit 1
+EOF
+cat > "$STATUS_BIN_DIR/wg" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+cat > "$STATUS_BIN_DIR/logger" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod 755 "$STATUS_BIN_DIR/uci" "$STATUS_BIN_DIR/wg" "$STATUS_BIN_DIR/logger"
+cat > "$STATUS_INIT" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$STATUS_CAPTURE"
+exit 0
+EOF
+chmod 755 "$STATUS_INIT"
+
+STATUS_JSON="$(
+	printf '{}' |
+		PATH="$STATUS_BIN_DIR:$PATH" \
+		NORDVPN_EASY_LIB_DIR="$LIB_DIR" \
+		NORDVPN_EASY_INIT_SCRIPT="$STATUS_INIT" \
+		NORDVPN_EASY_RUN_DIR="$STATUS_RUN_DIR" \
+		NORDVPN_EASY_RPC_AUTO_RECONCILE_COOLDOWN_SECONDS=300 \
+		sh "$RPCD_SCRIPT" call status
+)"
+printf '%s' "$STATUS_JSON" | jq -er '
+	.selected_country == "BO" and
+	.current_server_country == "AU"
+' >/dev/null
+for _attempt in 1 2 3 4 5; do
+	[ -s "$STATUS_CAPTURE" ] && break
+	sleep 1
+done
+[ "$(cat "$STATUS_CAPTURE" 2>/dev/null)" = 'reconcile' ] || {
+	printf '%s\n' 'FAIL: rpc status should queue reconcile for saved-country drift' >&2
+	exit 1
+}
+
+STATUS_JSON="$(
+	printf '{}' |
+		PATH="$STATUS_BIN_DIR:$PATH" \
+		NORDVPN_EASY_LIB_DIR="$LIB_DIR" \
+		NORDVPN_EASY_INIT_SCRIPT="$STATUS_INIT" \
+		NORDVPN_EASY_RUN_DIR="$STATUS_RUN_DIR" \
+		NORDVPN_EASY_RPC_AUTO_RECONCILE_COOLDOWN_SECONDS=300 \
+		sh "$RPCD_SCRIPT" call status
+)"
+assert_status_calls="$(wc -l < "$STATUS_CAPTURE" | awk '{ print $1 }')"
+[ "$assert_status_calls" = '1' ] || {
+	printf '%s\n' 'FAIL: rpc status auto reconcile should be throttled for the same drift key' >&2
+	exit 1
+}
+
 printf '%s\n' 'test-rpcd.sh: ok'

--- a/tests/nordvpn-easy/test-rpcd.sh
+++ b/tests/nordvpn-easy/test-rpcd.sh
@@ -281,8 +281,8 @@ for _attempt in 1 2 3 4 5; do
 	[ -s "$STATUS_CAPTURE" ] && break
 	sleep 1
 done
-[ "$(cat "$STATUS_CAPTURE" 2>/dev/null)" = 'reconcile' ] || {
-	printf '%s\n' 'FAIL: rpc status should queue reconcile for saved-country drift' >&2
+[ "$(cat "$STATUS_CAPTURE" 2>/dev/null)" = 'reconnect' ] || {
+	printf '%s\n' 'FAIL: rpc status should queue reconnect for saved-country drift' >&2
 	exit 1
 }
 


### PR DESCRIPTION
- **add safety net backend in nordvpn.easy**
- **Fix runtime server selection drift**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatically detects and recovers when the active VPN server differs from configured selection
  * Implements throttling to prevent excessive reconnection attempts

* **Tests**
  * Added comprehensive test coverage for server selection drift detection and automatic recovery workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tis24dev/NordVPN-Easy-OpenWrt/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->